### PR TITLE
[FEAT] 공통 toast 컴포넌트 구현

### DIFF
--- a/src/shared/ui/icon/index.ts
+++ b/src/shared/ui/icon/index.ts
@@ -1,3 +1,3 @@
 export * from './constants';
-export * from './Icon';
+export { default as Icon } from './Icon';
 export * from './types';

--- a/src/shared/ui/toast/Toast.stories.tsx
+++ b/src/shared/ui/toast/Toast.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Toast } from './index';
+
+const meta: Meta<typeof Toast> = {
+  title: 'Shared/UI/Toast',
+  component: Toast,
+  parameters: {
+    layout: 'centered',
+    backgrounds: {
+      default: 'gray', // 밝은 토스트가 잘 보이도록 배경 설정
+      values: [{ name: 'gray', value: '#F3F4F6' }],
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'success', 'error'],
+      description: '토스트의 스타일 변형입니다.',
+    },
+    message: {
+      control: 'text',
+      description: '토스트에 표시될 메시지입니다.',
+    },
+  },
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 기본 토스트 (성공 아이콘 + 메시지)
+export const Default: Story = {
+  args: {
+    variant: 'default',
+    message: '주소가 복사되었어요',
+  },
+};
+
+// 성공 토스트
+export const Success: Story = {
+  args: {
+    variant: 'success',
+    message: '작업이 성공했습니다',
+  },
+};
+
+// 에러 토스트
+export const Error: Story = {
+  args: {
+    variant: 'error',
+    message: '오류가 발생했습니다',
+  },
+};

--- a/src/shared/ui/toast/Toast.tsx
+++ b/src/shared/ui/toast/Toast.tsx
@@ -1,0 +1,58 @@
+import { HTMLAttributes, ReactNode } from 'react';
+
+import { Icon } from '../icon';
+
+interface ToastProps extends HTMLAttributes<HTMLDivElement> {
+  message: string;
+  variant?: 'default' | 'success' | 'error';
+  action?: ReactNode;
+}
+
+/**
+ * Toast 컴포넌트
+ */
+export default function Toast({
+  message,
+  variant = 'default',
+  action,
+  className = '',
+  ...props
+}: ToastProps) {
+  // 기본 클래스: Pill shape, White background, Shadow
+  // Tailwind Utility Class 사용
+  const baseClasses =
+    'inline-flex w-fit items-center gap-2 rounded-full bg-gray-0 px-5 py-3 shadow-[0px_0px_12px_0px_rgba(0,0,0,0.1)]';
+
+  // 텍스트 스타일: text-primary
+  // Pretendard 폰트 특성상 영문/숫자 대비 한글이 시각적으로 약간 위로 떠보일 수 있어 pt-[2px]로 보정
+  const textClass = 'text-text-primary text-title-6 font-semibold pt-[2px]';
+
+  const combinedClasses = `${baseClasses} ${className}`;
+
+  return (
+    <div className={combinedClasses} role='alert' {...props}>
+      {/* 아이콘: Success/Default는 Blue Check, Error는 Red X */}
+      <div className='flex items-center'>
+        {variant === 'error' ? (
+          <Icon
+            name='ic_circle_x_filled'
+            size={24}
+            className='text-status-error'
+          />
+        ) : (
+          <Icon
+            name='ic_circle_check_filled'
+            size={24}
+            className='text-primary-default'
+          />
+        )}
+      </div>
+
+      {/* 메시지 */}
+      <div className={textClass}>{message}</div>
+
+      {/* 액션 버튼 (선택 사항) */}
+      {action && <div className='shrink-0'>{action}</div>}
+    </div>
+  );
+}

--- a/src/shared/ui/toast/index.ts
+++ b/src/shared/ui/toast/index.ts
@@ -1,0 +1,1 @@
+export { default as Toast } from './Toast';


### PR DESCRIPTION
# 🚩 연관 이슈

closed #28

# 📝 작업 내용

## 공통 toast 컴포넌트 구현
- 공통 UI로 사용할 수 있는 Toast 컴포넌트 추가
- 메시지, 상태(variant), 액션 영역을 유연하게 조합 가능하도록 설계
- variant에 따라 아이콘 및 컬러 분기
- default / success → 체크 아이콘
- error → 에러 아이콘
- action prop을 통해 버튼 등 커스텀 액션 삽입 가능
- HTMLAttributes<HTMLDivElement> 확장으로 className 및 DOM 속성 전달 지원

<img width="1042" height="294" alt="image" src="https://github.com/user-attachments/assets/4ba83d05-9403-4144-9767-3c8d4b570b5c" />

