### PR TITLE
[FEAT] 공통 tooltip 컴포넌트 구현

### DIFF
--- a/src/shared/ui/tooltip/Tooltip.stories.tsx
+++ b/src/shared/ui/tooltip/Tooltip.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import Tooltip from './Tooltip';
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'Shared/UI/Tooltip',
+  component: Tooltip,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    message: { control: 'text' },
+    visible: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {
+  args: {
+    message: '툴팁 내용이 들어갑니다',
+    children: (
+      <button className='rounded bg-gray-200 px-4 py-2'>
+        마우스를 올려보세요
+      </button>
+    ),
+  },
+};
+
+export const AlwaysVisible: Story = {
+  args: {
+    message: '항상 보이는 툴팁',
+    children: <div className='h-10 w-10 rounded-full bg-blue-500' />,
+    visible: true,
+  },
+};

--- a/src/shared/ui/tooltip/Tooltip.tsx
+++ b/src/shared/ui/tooltip/Tooltip.tsx
@@ -1,0 +1,49 @@
+import { ReactNode } from 'react';
+
+interface TooltipProps {
+  /**
+   * 툴팁에 표시될 메시지입니다.
+   */
+  message: string;
+  /**
+   * 툴팁을 트리거할 요소입니다.
+   */
+  children?: ReactNode;
+  /**
+   * 추가적인 스타일 클래스입니다.
+   */
+  className?: string;
+  /**
+   * 툴팁의 가시성 여부입니다. true일 경우 항상 보입니다. (Storybook 또는 개발용)
+   */
+  visible?: boolean;
+}
+
+export default function Tooltip({
+  message,
+  children,
+  className = '',
+  visible,
+}: TooltipProps) {
+  return (
+    <div
+      className={`group relative inline-flex flex-col items-center justify-center ${className}`}
+    >
+      {children}
+
+      {/* 툴팁 콘텐츠 - 기본적으로 Figma 구조에 따라 아래쪽에 위치 (화살표 다음 본문) */}
+      {/* 기본적으로 숨겨져 있으며, 그룹 호버 시 또는 visible=true일 때 표시됨 */}
+      <div
+        className={`absolute top-full left-1/2 z-50 mt-2 flex -translate-x-1/2 flex-col items-center transition-opacity duration-200 ${visible ? 'visible opacity-100' : 'invisible opacity-0 group-hover:visible group-hover:opacity-100'} drop-shadow-[0_0_8px_rgba(0,0,0,0.2)]`}
+      >
+        {/* 위쪽 화살표 */}
+        <div className='-mb-px h-0 w-0 border-r-[6px] border-b-[6px] border-l-[6px] border-r-transparent border-b-gray-800 border-l-transparent' />
+
+        {/* 본문 */}
+        <div className='text-text-inverse min-w-max rounded-full bg-gray-800 px-3 py-1.5'>
+          <p className='text-body-5 whitespace-nowrap'>{message}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/ui/tooltip/index.ts
+++ b/src/shared/ui/tooltip/index.ts
@@ -1,0 +1,1 @@
+export { default as Tooltip } from './Tooltip';


### PR DESCRIPTION
# 🚩 연관 이슈

closed #32

# 📝 작업 내용
- 공통 UI로 사용할 Tooltip 컴포넌트 추가
- 트리거 요소에 hover 시 메시지를 노출하는 구조
- message prop으로 툴팁 텍스트 전달
- children을 툴팁 트리거로 사용
- visible 옵션으로 항상 표시 가능 (Storybook / 개발용)
- group-hover 기반 hover 제어

<img width="284" height="126" alt="image" src="https://github.com/user-attachments/assets/d94fccbc-174e-4688-a074-9789c3ab4752" />


# 🗣️ 리뷰 요구사항 (선택)
