### PR TITLE
[FEAT] 공통 header 컴포넌트 구현

### DIFF
--- a/src/shared/ui/header/Header.stories.tsx
+++ b/src/shared/ui/header/Header.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Header } from './Header';
+
+const meta: Meta<typeof Header> = {
+  title: 'Shared/UI/Header',
+  component: Header,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'subHeader', 'thirdTitle'],
+      description: '헤더의 스타일 변형을 선택합니다.',
+    },
+    title: {
+      control: 'text',
+      description: '헤더의 메인 타이틀입니다.',
+    },
+    subTitle: {
+      control: 'text',
+      description: '서브 헤더나 Third Title에서 사용되는 서브 텍스트입니다.',
+    },
+    voteCount: {
+      control: 'number',
+      description: 'Default 변형에서 사용되는 투표 수입니다.',
+    },
+    standardTime: {
+      control: 'text',
+      description: 'Default 변형에서 사용되는 기준 시간입니다.',
+    },
+    onRefresh: { action: 'refreshed' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Header>;
+
+export const Default: Story = {
+  args: {
+    variant: 'default',
+    voteCount: 8,
+    standardTime: '20:13',
+  },
+};
+
+export const SubHeader: Story = {
+  args: {
+    variant: 'subHeader',
+    title: '텍스트가 두 줄로 들어갑니다.',
+  },
+};
+
+export const ThirdTitle: Story = {
+  args: {
+    variant: 'thirdTitle',
+    title: '텍스트가 두 줄로 들어갑니다.',
+    subTitle: '서브 텍스트가 들어갑니다.',
+  },
+};

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -1,0 +1,118 @@
+interface HeaderProps {
+  /**
+   * 헤더의 변형(Variant)을 결정합니다.
+   * - default: 투표 수와 기준 시간이 표시되는 헤더
+   * - subHeader: 타이틀만 있는 서브 헤더
+   * - thirdTitle: 타이틀과 서브 타이틀이 있는 헤더
+   */
+  variant?: 'default' | 'subHeader' | 'thirdTitle';
+
+  /**
+   * 메인 타이틀 텍스트입니다.
+   * Variant가 'default'일 때는 투표 수 텍스트를 대체합니다(옵션).
+   */
+  title?: string;
+
+  /**
+   * 서브 타이틀 텍스트입니다.
+   * Variant가 'thirdTitle'일 때 사용됩니다.
+   */
+  subTitle?: string;
+
+  /**
+   * (Default Variant 전용) 투표 참여 인원 수입니다.
+   * 이 값이 있으면 title 대신 "X명이 투표했어요" 형태의 텍스트가 렌더링됩니다.
+   */
+  voteCount?: number;
+
+  /**
+   * (Default Variant 전용) 기준 시간 텍스트입니다. 예: "20:13"
+   */
+  standardTime?: string;
+
+  /**
+   * (Default Variant 전용) 새로고침 아이콘 클릭 핸들러입니다.
+   */
+  onRefresh?: () => void;
+
+  className?: string;
+}
+
+export function Header({
+  variant = 'default',
+  title,
+  subTitle,
+  voteCount,
+  standardTime,
+  onRefresh,
+  className = '',
+}: HeaderProps) {
+  return (
+    <header className={`flex w-full flex-col ${className}`}>
+      {/* Default Variant */}
+      {variant === 'default' && (
+        <div className='flex w-full items-center justify-between bg-white px-5 pt-6 pb-2'>
+          <div className='text-headline-5 text-text-primary'>
+            {voteCount !== undefined ? (
+              <>
+                <span className='text-primary-default'>{voteCount}</span>
+                <span>명이 투표했어요</span>
+              </>
+            ) : (
+              title
+            )}
+          </div>
+
+          {(standardTime || onRefresh) && (
+            <button
+              onClick={onRefresh}
+              className='text-text-tertiary text-caption-6 flex items-center gap-1'
+              type='button'
+            >
+              {/* Refresh Icon Placeholder or SVG */}
+              <svg
+                width='16'
+                height='16'
+                viewBox='0 0 16 16'
+                fill='none'
+                xmlns='http://www.w3.org/2000/svg'
+              >
+                <path
+                  d='M8 1.3335C4.3181 1.3335 1.33333 4.31826 1.33333 8.00016C1.33333 11.6821 4.3181 14.6668 8 14.6668C11.6819 14.6668 14.6667 11.6821 14.6667 8.00016C14.6667 6.46889 14.149 5.06456 13.284 3.96266'
+                  stroke='currentColor'
+                  strokeWidth='1.2'
+                  strokeLinecap='round'
+                />
+                <path
+                  d='M13.3333 1.3335V4.00016H10.6667'
+                  stroke='currentColor'
+                  strokeWidth='1.2'
+                  strokeLinecap='round'
+                  strokeLinejoin='round'
+                />
+              </svg>
+              <span>{standardTime} 기준</span>
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* SubHeader Variant */}
+      {variant === 'subHeader' && (
+        <div className='flex w-full items-center bg-white px-5 pt-6 pb-2'>
+          <h2 className='text-title-4 text-text-primary'>{title}</h2>
+        </div>
+      )}
+
+      {/* ThirdTitle Variant */}
+      {variant === 'thirdTitle' && (
+        <div className='flex w-full flex-col gap-1 bg-white px-5 pt-6 pb-2'>
+          <h2 className='text-headline-5 text-text-primary'>{title}</h2>
+          {subTitle && (
+            <p className='text-body-5 text-text-tertiary'>{subTitle}</p>
+          )}
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -1,3 +1,5 @@
+import Icon from '../icon/Icon';
+
 interface HeaderProps {
   /**
    * 헤더의 변형(Variant)을 결정합니다.
@@ -70,27 +72,7 @@ export function Header({
               type='button'
             >
               {/* Refresh Icon Placeholder or SVG */}
-              <svg
-                width='16'
-                height='16'
-                viewBox='0 0 16 16'
-                fill='none'
-                xmlns='http://www.w3.org/2000/svg'
-              >
-                <path
-                  d='M8 1.3335C4.3181 1.3335 1.33333 4.31826 1.33333 8.00016C1.33333 11.6821 4.3181 14.6668 8 14.6668C11.6819 14.6668 14.6667 11.6821 14.6667 8.00016C14.6667 6.46889 14.149 5.06456 13.284 3.96266'
-                  stroke='currentColor'
-                  strokeWidth='1.2'
-                  strokeLinecap='round'
-                />
-                <path
-                  d='M13.3333 1.3335V4.00016H10.6667'
-                  stroke='currentColor'
-                  strokeWidth='1.2'
-                  strokeLinecap='round'
-                  strokeLinejoin='round'
-                />
-              </svg>
+              <Icon name='ic_refresh' size={16} />
               <span>{standardTime} 기준</span>
             </button>
           )}

--- a/src/shared/ui/header/index.ts
+++ b/src/shared/ui/header/index.ts
@@ -1,0 +1,1 @@
+export { Header } from './Header';


### PR DESCRIPTION
# 🚩 연관 이슈

closed #34

# 📝 작업 내용
- 공통으로 사용할 Header 컴포넌트 구현
- variant prop에 따라 서로 다른 헤더 레이아웃 렌더링

- default
    - 투표 참여 인원(voteCount) 표시
    - 기준 시간(standardTime) 및 새로고침 버튼 제공
- subHeader
    - 타이틀만 있는 단순 헤더
- thirdTitle
    - 타이틀 + 서브 타이틀 구조

# 🗣️ 리뷰 요구사항 (선택)
