### PR TITLE
[FEAT] 공통 buttom sheet 컴포넌트 구현

### DIFF
--- a/src/shared/ui/bottom-sheet/BottomSheet.stories.tsx
+++ b/src/shared/ui/bottom-sheet/BottomSheet.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useState } from 'react';
+
+import BottomSheet from './BottomSheet';
+
+const meta: Meta<typeof BottomSheet> = {
+  title: 'Shared/UI/BottomSheet',
+  component: BottomSheet,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof BottomSheet>;
+
+const BottomSheetWithHooks = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className='flex h-screen w-full items-center justify-center bg-gray-100 p-4'>
+      <button
+        className='rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700'
+        onClick={() => setIsOpen(true)}
+      >
+        Open BottomSheet
+      </button>
+      {isOpen && (
+        <BottomSheet onClose={() => setIsOpen(false)}>
+          <div className='px-5'>
+            <h2 className='text-title-2 text-text-primary mb-2'>
+              Bottom Sheet Title
+            </h2>
+            <p className='text-body-2 text-text-secondary'>
+              Here is some content inside the bottom sheet. You can put anything
+              here.
+            </p>
+            <div className='mt-4 flex flex-col gap-2'>
+              <button className='bg-primary-default w-full rounded py-3 font-medium text-white'>
+                Confirm
+              </button>
+              <button
+                className='text-text-secondary w-full rounded bg-gray-100 py-3 font-medium'
+                onClick={() => setIsOpen(false)}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </BottomSheet>
+      )}
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => <BottomSheetWithHooks />,
+};

--- a/src/shared/ui/bottom-sheet/BottomSheet.tsx
+++ b/src/shared/ui/bottom-sheet/BottomSheet.tsx
@@ -1,0 +1,25 @@
+import type { PropsWithChildren } from 'react';
+
+import Icon from '../icon/Icon';
+
+interface BottomSheetProps extends PropsWithChildren {
+  onClose: () => void;
+}
+
+export default function BottomSheet({ onClose, children }: BottomSheetProps) {
+  return (
+    <div className='bg-gray-0 flex w-full flex-col rounded-t-xl pb-5 shadow-lg'>
+      <div className='flex w-full justify-end pt-4 pr-5'>
+        <button
+          type='button'
+          onClick={onClose}
+          className='text-text-primary flex h-6 w-6 items-center justify-center active:scale-95'
+          aria-label='닫기'
+        >
+          <Icon name='ic_menu_close' size={24} />
+        </button>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/shared/ui/bottom-sheet/index.ts
+++ b/src/shared/ui/bottom-sheet/index.ts
@@ -1,0 +1,1 @@
+export { default as BottomSheet } from './BottomSheet';


### PR DESCRIPTION
# 🚩 연관 이슈

closed #36

# 📝 작업 내용
공통 buttom sheet 컴포넌트 구현

<img width="524" height="312" alt="image" src="https://github.com/user-attachments/assets/5a7895b5-0f6d-4e82-8df8-1eadbb9a9a3a" />


# 🗣️ 리뷰 요구사항 (선택)
해당 UI를 구현할 때 bottom sheet에 걸맞게 로직적인 측면까지 구현해야할지 아니면 단순 UI만 구현할지 고민을 했습니다. next.js니 페러렐 라우너와 인터셉터 라우터로 모달을 구현할 수 있으니 일단, UI만 구현하는 방식을 채택했는데 그냥 모달형식으로 리액트로 바로 구현하는 방식으로 구현하는 것도 괜찮아 보입니다. 일단