### PR TITLE
feat/#27 주최자 모임생성 플로우

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+
+import MeetCreatePage from '@/features/meet-create/ui/MeetCreatePage';
+
+export default function CreateMeetingPage() {
+  const searchParams = useSearchParams();
+
+  const initialHostName = searchParams.get('hostName') || '';
+  const initialMeetingName = searchParams.get('meetingName') || '';
+
+  return (
+    <MeetCreatePage
+      initialHostName={initialHostName}
+      initialMeetingName={initialMeetingName}
+    />
+  );
+}

--- a/src/app/date/page.tsx
+++ b/src/app/date/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+
+import DateSelectPageContent from '@/features/meet-create-date/ui/DateSelectPage';
+
+export default function DateSelectPage() {
+  const searchParams = useSearchParams();
+
+  const hostName = searchParams.get('hostName') || '';
+  const meetingName = searchParams.get('meetingName') || '';
+
+  return (
+    <DateSelectPageContent hostName={hostName} meetingName={meetingName} />
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,28 @@
+import Link from 'next/link';
+
+import Button from '@/shared/ui/button/Button';
+
 export default function OnboardingPage() {
   return (
-    <div className='flex min-h-screen items-center justify-center'>
-      <div className='text-center'>
-        <h1 className='text-headline-1 text-text-primary mb-4'>
-          온보딩 페이지
-        </h1>
+    <div className='flex min-h-screen flex-col items-center justify-between px-5 py-10'>
+      <div className='flex flex-1 items-center justify-center'>
+        <div className='text-center'>
+          {/* TODO: 실제 로고 이미지로 교체 필요 */}
+          <div className='mb-8 flex justify-center'>
+            <div className='bg-primary-default flex h-24 w-24 items-center justify-center rounded-full'>
+              <span className='text-headline-2 text-text-inverse'>LOGO</span>
+            </div>
+          </div>
+
+          <h1 className='text-headline-2 text-text-primary mb-4'>
+            온보딩 페이지
+          </h1>
+        </div>
       </div>
+
+      <Link href='/create' className='w-full'>
+        <Button fullWidth>시작하기</Button>
+      </Link>
     </div>
   );
 }

--- a/src/features/meet-create-date/model/useDateSelect.ts
+++ b/src/features/meet-create-date/model/useDateSelect.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+export function useDateSelect(hostName: string, meetingName: string) {
+  const router = useRouter();
+
+  const handleBack = () => {
+    const params = new URLSearchParams({
+      hostName,
+      ...(meetingName && { meetingName }),
+    });
+    router.push(`/create?${params.toString()}`);
+  };
+
+  const handleNext = () => {
+    // TODO: API 연동 - 모임 생성
+    console.log({ hostName, meetingName });
+  };
+
+  return {
+    handleBack,
+    handleNext,
+  };
+}

--- a/src/features/meet-create-date/ui/DateSelectPage.tsx
+++ b/src/features/meet-create-date/ui/DateSelectPage.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import Button from '@/shared/ui/button';
+import TopBar from '@/shared/ui/top-bar/TopBar';
+
+import { useDateSelect } from '../model/useDateSelect';
+
+interface DateSelectPageProps {
+  hostName: string;
+  meetingName: string;
+}
+
+export default function DateSelectPage({
+  hostName,
+  meetingName,
+}: DateSelectPageProps) {
+  const { handleBack, handleNext } = useDateSelect(hostName, meetingName);
+
+  return (
+    <div className='bg-gray-0 flex min-h-screen flex-col'>
+      {/* 헤더 */}
+      <TopBar
+        title='모임 만들기'
+        leftIcon='arrow_prev'
+        onLeftClick={handleBack}
+      />
+
+      {/* 메인 콘텐츠 */}
+      <main className='flex flex-1 flex-col px-5 pt-6 pb-10'>
+        {/* 타이틀 */}
+        <h1 className='text-title-4 text-text-primary mb-6'>
+          참여자들이 투표할
+          <br />
+          날짜 범위를 선택해주세요
+        </h1>
+
+        {/* 캘린더 영역 (플레이스홀더) */}
+        <div className='mb-6 flex flex-1 items-center justify-center rounded-lg border border-gray-200 bg-white'>
+          <p className='text-text-tertiary text-body-3'>캘린더 영역</p>
+        </div>
+
+        {/* CTA 버튼 */}
+        <Button onClick={handleNext} fullWidth>
+          모임 만들기
+        </Button>
+      </main>
+    </div>
+  );
+}

--- a/src/features/meet-create/model/useMeetCreateForm.ts
+++ b/src/features/meet-create/model/useMeetCreateForm.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState } from 'react';
+
+export function useMeetCreateForm(
+  initialHostName = '',
+  initialMeetingName = '',
+) {
+  const [hostName, setHostName] = useState(initialHostName);
+  const [meetingName, setMeetingName] = useState(initialMeetingName);
+  const [hostNameError, setHostNameError] = useState('');
+
+  const validateHostName = (value: string) => {
+    // 한글, 영문(대소문자)만 허용하는 정규식
+    const koreanEnglishOnly = /^[ㄱ-힣a-zA-Z]*$/;
+
+    if (value && !koreanEnglishOnly.test(value)) {
+      setHostNameError('한글, 영문만 입력 가능해요');
+    } else {
+      setHostNameError('');
+    }
+  };
+
+  const handleHostNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    setHostName(newValue);
+    validateHostName(newValue);
+  };
+
+  const handleHostNameClear = () => {
+    setHostName('');
+    setHostNameError('');
+  };
+
+  const handleMeetingNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setMeetingName(e.target.value);
+  };
+
+  const handleMeetingNameClear = () => {
+    setMeetingName('');
+  };
+
+  const isValid = hostName.trim() !== '' && !hostNameError;
+
+  return {
+    hostName,
+    meetingName,
+    hostNameError,
+    isValid,
+    handleHostNameChange,
+    handleHostNameClear,
+    handleMeetingNameChange,
+    handleMeetingNameClear,
+  };
+}

--- a/src/features/meet-create/ui/MeetCreatePage.tsx
+++ b/src/features/meet-create/ui/MeetCreatePage.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import Button from '@/shared/ui/button/Button';
+import Input from '@/shared/ui/input/Input';
+import TopBar from '@/shared/ui/top-bar/TopBar';
+
+import { useMeetCreateForm } from '../model/useMeetCreateForm';
+
+interface MeetCreatePageProps {
+  initialHostName?: string;
+  initialMeetingName?: string;
+}
+
+export default function MeetCreatePage({
+  initialHostName = '',
+  initialMeetingName = '',
+}: MeetCreatePageProps) {
+  const router = useRouter();
+  const {
+    hostName,
+    meetingName,
+    hostNameError,
+    isValid,
+    handleHostNameChange,
+    handleHostNameClear,
+    handleMeetingNameChange,
+    handleMeetingNameClear,
+  } = useMeetCreateForm(initialHostName, initialMeetingName);
+
+  const handleBack = () => {
+    router.push('/');
+  };
+
+  const handleSubmit = () => {
+    const params = new URLSearchParams({
+      hostName: hostName.trim(),
+      ...(meetingName.trim() && { meetingName: meetingName.trim() }),
+    });
+    router.push(`/date?${params.toString()}`);
+  };
+
+  return (
+    <div className='bg-gray-0 flex min-h-screen flex-col'>
+      <TopBar
+        title='모임 만들기'
+        leftIcon='arrow_prev'
+        onLeftClick={handleBack}
+      />
+
+      <main className='flex flex-1 flex-col px-5 pt-6 pb-10'>
+        <h1 className='text-title-4 text-text-primary mb-4'>
+          투표를 시작할
+          <br />
+          모임을 만들어주세요
+        </h1>
+
+        <div className='flex flex-col gap-1'>
+          <div className='mt-1 flex flex-col gap-1.5'>
+            <label className='input-label text-title-8'>
+              모임장 이름 <span className='text-status-error'>*</span>
+            </label>
+            <Input
+              value={hostName}
+              onChange={handleHostNameChange}
+              onClear={handleHostNameClear}
+              placeholder='이름을 입력해주세요'
+              maxLength={10}
+              fullWidth
+              required
+              errorMessage={hostNameError}
+            />
+          </div>
+
+          <Input
+            label='모임명'
+            value={meetingName}
+            onChange={handleMeetingNameChange}
+            onClear={handleMeetingNameClear}
+            placeholder='멋지고 이쁜 모임'
+            maxLength={10}
+            fullWidth
+          />
+        </div>
+
+        <div className='flex-1' />
+
+        <Button onClick={handleSubmit} disabled={!isValid} fullWidth>
+          날짜 선택하기
+        </Button>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #27

# 📝 작업 내용

## 구현 페이지
- 온보딩 페이지
- 모임 생성 페이지 (주최자 이름, 모임명 입력)
- 모임 날짜 선택 페이지

## 주요 구현 사항
- FSD 아키텍처 기반 features 폴더 구조 구성
  - `features/meet-create`: 모임 생성 페이지 로직 및 UI
  - `features/meet-create-date`: 날짜 선택 페이지 로직 및 UI
- 커스텀 훅을 통한 상태 관리
  - `useMeetCreateForm`: 모임 생성 폼 상태 및 검증 로직
  - `useDateSelect`: 날짜 선택 상태 관리
- Input 컴포넌트 검증 기능
  - 주최자 이름: 한글/영문만 입력 가능하도록 실시간 검증
  - 에러 메시지 표시 (errorMessage prop 활용)

# 🗣️ 리뷰 요구사항 (선택)