### PR TITLE
feat/#50 모임 투표 메인 화면

### DIFF
--- a/src/app/meet/[meetingId]/page.tsx
+++ b/src/app/meet/[meetingId]/page.tsx
@@ -1,56 +1,15 @@
+import { getMeetingById } from '@/entities/meet/api/getMeetingById';
+import { type Participant } from '@/entities/meet/dto/meet.dto';
 import { Person } from '@/shared/types/common';
 import Button from '@/shared/ui/button/Button';
 import { Header } from '@/shared/ui/header';
 import { TopBar } from '@/shared/ui/top-bar';
 import { VoteResultDataView } from '@/widgets/vote-result/ui/VoteResultDataView';
 
-// 1. Mock Data based on User Schema
-const MOCK_DATA = {
-  id: 'meeting-123',
-  title: '신년 모임 날짜 투표',
-  dates: [
-    '2026-01-14',
-    '2026-01-15',
-    '2026-01-16',
-    '2026-01-17',
-    '2026-01-20',
-    '2026-01-21',
-    '2026-01-22',
-  ], // Candidate dates
-  maxParticipantCount: 0,
-  participants: [
-    {
-      id: '1',
-      name: '김철수',
-      voteDates: ['2026-01-14', '2026-01-15', '2026-01-16'],
-    },
-    {
-      id: '2',
-      name: '이영희',
-      voteDates: ['2026-01-14', '2026-01-15'],
-    },
-    {
-      id: '3',
-      name: '박민수',
-      voteDates: ['2026-01-14', '2026-01-17'],
-    },
-    {
-      id: '4',
-      name: '최지혜',
-      voteDates: ['2026-01-20'],
-    },
-    {
-      id: '5',
-      name: '정수빈',
-      voteDates: ['2026-01-14', '2026-01-15', '2026-01-16', '2026-01-17'],
-    },
-  ],
-};
-
-// 2. Transform Logic
-function getStatsFromMock(
+// Transform Logic
+function getStatsFromParticipants(
   candidateDates: string[],
-  participants: { id: string; name: string; voteDates: string[] }[],
+  participants: Participant[],
 ) {
   return candidateDates.map((date) => {
     const can: Person[] = [];
@@ -58,9 +17,9 @@ function getStatsFromMock(
 
     participants.forEach((p) => {
       if (p.voteDates.includes(date)) {
-        can.push({ id: p.id, name: p.name });
+        can.push({ id: String(p.id), name: p.name });
       } else {
-        cannot.push({ id: p.id, name: p.name });
+        cannot.push({ id: String(p.id), name: p.name });
       }
     });
 
@@ -79,32 +38,45 @@ interface ResultPageProps {
 }
 
 export default async function ResultPage({ params }: ResultPageProps) {
-  const {} = await params;
+  const { meetingId } = await params;
+
+  // Fetch meeting data from API
+  const meetingData = await getMeetingById(meetingId);
 
   // Derive stats
-  const stats = getStatsFromMock(MOCK_DATA.dates, MOCK_DATA.participants);
+  const stats = getStatsFromParticipants(
+    meetingData.dates,
+    meetingData.participants,
+  );
 
   // Derive date range (min/max of candidate dates)
-  const sortedDates = [...MOCK_DATA.dates].sort();
+  const sortedDates = [...meetingData.dates].sort();
   const openRange = {
     start: sortedDates[0],
     end: sortedDates[sortedDates.length - 1],
   };
 
   // Extract participant names for the dropdown
-  const participantNames = MOCK_DATA.participants.map((p) => p.name);
+  const participantNames = meetingData.participants.map((p) => p.name);
+
+  // 데이터 로드 시간 (HH:MM 형식)
+  const now = new Date();
+  const standardTime = `${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}`;
 
   return (
     <div className='flex min-h-screen flex-col bg-gray-50 pt-14 pb-25'>
       <div className='fixed top-0 right-0 left-0 z-50 mx-auto w-full max-w-screen-sm bg-white'>
         <TopBar
-          title='어쩔래미저쩔래님이 초대한 두쫀쿠투어두쫀'
+          title={meetingData.title}
           rightIcon='ic_other_share'
           className='bg-white'
         />
       </div>
 
-      <Header voteCount={MOCK_DATA.participants.length} />
+      <Header
+        voteCount={meetingData.participants.length}
+        standardTime={standardTime}
+      />
 
       <VoteResultDataView
         participantNames={participantNames}

--- a/src/entities/meet/api/getMeetingById.ts
+++ b/src/entities/meet/api/getMeetingById.ts
@@ -10,7 +10,7 @@ import { type MeetResponse, meetResponseDto } from '../dto/meet.dto';
  * @returns 모임 정보와 참여자 투표 현황 (스키마 검증 완료)
  */
 export async function getMeetingById(meetId: string): Promise<MeetResponse> {
-  const ENDPOINT = `/api/v1/meeting`;
+  const ENDPOINT = `v1/meeting`;
 
   // 1) 실제 HTTP 요청 (query parameter로 meetId 전달)
   const rawResponse = await api

--- a/src/entities/meet/dto/meet.dto.ts
+++ b/src/entities/meet/dto/meet.dto.ts
@@ -44,7 +44,7 @@ export const meetResponseDto = z.object({
   id: z.string(),
   title: z.string(),
   dates: z.array(z.string()),
-  maxParticipantCount: z.number(),
+  maxParticipantCount: z.number().nullable(),
   participants: z.array(participantDto),
 });
 

--- a/src/widgets/vote-result/ui/VoteResultDataView.tsx
+++ b/src/widgets/vote-result/ui/VoteResultDataView.tsx
@@ -32,14 +32,14 @@ export function VoteResultDataView({
   };
 
   return (
-    <div className='flex w-full flex-col items-center px-5 py-6'>
+    <div className='flex w-full flex-col items-center px-5 py-2'>
       <div className='w-full space-y-4'>
         {/* Dropdown for participants */}
         <Dropdown
           participants={participantNames}
           selectedParticipant={selectedParticipant}
           onSelectParticipant={handleParticipantSelect}
-          className='mb-6'
+          className='mb-2'
         />
 
         <ReactDatePickerVoteResultsCalendar


### PR DESCRIPTION
# 🚩 연관 이슈

closed #50

# 📝 작업 내용

- 모임 투표 화면 디자인 보완
- 모임 투표 정보 조회 API 연동
- 임시 프록시 설정 제거 (CORS 해결됨)
- 모임 생성 플로우 캘린더 연동 및 생성 API 연동
- participant → meet 라우트 경로 변경

# 🗣️ 리뷰 요구사항 (선택)