### PR TITLE
[FEAT] 복사 버튼 클릭 시,toast UI가 렌더링 되도록 추가

### DIFF
--- a/src/shared/ui/bottom-sheet/LinkShareBottomSheet.tsx
+++ b/src/shared/ui/bottom-sheet/LinkShareBottomSheet.tsx
@@ -2,10 +2,12 @@
 
 import copy from 'copy-to-clipboard';
 import { useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import BottomSheet from '@/shared/ui/bottom-sheet/BottomSheet';
 import Button from '@/shared/ui/button/Button';
 import Chip from '@/shared/ui/chip/Chip';
+import Toast from '@/shared/ui/toast/Toast';
 
 interface LinkShareBottomSheetProps {
   isOpen: boolean;
@@ -27,12 +29,16 @@ export default function LinkShareBottomSheet({
   shareText = '모임 투표 링크가 생성됐어요!',
 }: LinkShareBottomSheetProps) {
   const [isCopied, setIsCopied] = useState(false);
+  const [showToast, setShowToast] = useState(false);
 
   const handleCopy = () => {
     copy(url);
     setIsCopied(true);
+    setShowToast(true);
+
     setTimeout(() => {
       setIsCopied(false);
+      setShowToast(false);
     }, 2000);
   };
 
@@ -54,37 +60,47 @@ export default function LinkShareBottomSheet({
     } else {
       // Fallback for desktop or unsupported browsers
       handleCopy();
-      alert('공유하기가 지원되지 않는 환경입니다. 링크가 복사되었습니다.');
     }
   };
 
   return (
-    <BottomSheet isOpen={isOpen} onClose={onClose}>
-      <div className='flex flex-col items-center px-5 pt-2 pb-5 text-center'>
-        <h2 className='text-headline-5 mb-1 text-gray-900'>{title}</h2>
-        <p className='text-body-2 mb-8 text-gray-500'>{description}</p>
+    <>
+      <BottomSheet isOpen={isOpen} onClose={onClose}>
+        <div className='flex flex-col items-center px-5 pt-2 pb-5 text-center'>
+          <h2 className='text-headline-5 mb-1 text-gray-900'>{title}</h2>
+          <p className='text-body-2 mb-8 text-gray-500'>{description}</p>
 
-        {/* Link Box */}
-        <div className='mb-4 flex w-full items-center justify-between rounded-lg bg-slate-100 px-4 py-3'>
-          <span className='text-body-2 truncate text-gray-500'>{url}</span>
-          <Chip
-            text={isCopied ? '복사완료' : '복사'}
-            variant={isCopied ? 'fill' : 'line'}
-            size='sm'
-            selected
-            onClick={handleCopy}
-            className='ml-3'
-          />
+          {/* Link Box */}
+          <div className='mb-4 flex w-full items-center justify-between rounded-lg bg-slate-100 px-4 py-3'>
+            <span className='text-body-2 truncate text-gray-500'>{url}</span>
+            <Chip
+              text={isCopied ? '복사완료' : '복사'}
+              variant={isCopied ? 'fill' : 'line'}
+              size='sm'
+              selected
+              onClick={handleCopy}
+              className='ml-3'
+            />
+          </div>
+
+          <Button
+            fullWidth
+            onClick={handleShare}
+            className='hover:bg-opacity-90 bg-gray-800 font-bold'
+          >
+            링크 공유하기
+          </Button>
         </div>
-
-        <Button
-          fullWidth
-          onClick={handleShare}
-          className='hover:bg-opacity-90 bg-gray-800 font-bold'
-        >
-          링크 공유하기
-        </Button>
-      </div>
-    </BottomSheet>
+      </BottomSheet>
+      {showToast &&
+        createPortal(
+          <Toast
+            message='주소가 복사되었어요'
+            variant='success'
+            className='fixed top-8 left-1/2 z-[100] -translate-x-1/2'
+          />,
+          document.body,
+        )}
+    </>
   );
 }

--- a/src/shared/ui/toast/Toast.tsx
+++ b/src/shared/ui/toast/Toast.tsx
@@ -25,7 +25,7 @@ export default function Toast({
 
   // 텍스트 스타일: text-primary
   // Pretendard 폰트 특성상 영문/숫자 대비 한글이 시각적으로 약간 위로 떠보일 수 있어 pt-[2px]로 보정
-  const textClass = 'text-text-primary text-title-6 font-semibold pt-[2px]';
+  const textClass = 'text-text-primary text-title-8 pt-[2px]';
 
   const combinedClasses = `${baseClasses} ${className}`;
 
@@ -36,7 +36,7 @@ export default function Toast({
         {variant === 'error' ? (
           <Icon
             name='ic_circle_x_filled'
-            size={24}
+            size={20}
             className='text-status-error'
           />
         ) : (


### PR DESCRIPTION
# 🚩 연관 이슈

closed #62

# 📝 작업 내용
<img width="372" height="669" alt="image" src="https://github.com/user-attachments/assets/c8fb5557-1f90-4913-b4f1-5e0c150ef834" />

복사 버튼 클릭 시, toast ui가 렌더링 되도록 구현

# 🗣️ 리뷰 요구사항 (선택)
