### PR TITLE
[FIX] 갤리더 월 이동 시, UI가 변경되는 문제 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -506,7 +506,8 @@
 }
 
 /* Hide screen reader only text visually */
-.react-datepicker__sr-only {
+.react-datepicker__sr-only,
+.react-datepicker__aria-live {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -615,4 +616,9 @@
 }
 .rmdp-day.rmdp-selected span:not(.highlight) {
   background-color: #2563eb !important;
+}
+
+/* Vote Result Calendar에서 기본 헤더(년월)가 중복 노출되는 문제 해결 */
+.vote-result-calendar .react-datepicker__current-month {
+  display: none !important;
 }


### PR DESCRIPTION
# 🚩 연관 이슈

closed #70

# 📝 작업 내용
참여자 메인화면에서 월 이동 시, 우측 상단에 년도 월이 중복으로 표시되는 문제 해결
- before
<img width="643" height="489" alt="image" src="https://github.com/user-attachments/assets/f598701a-d81c-41ec-8053-e6d1dd39a739" />

- after
<img width="643" height="489" alt="image" src="https://github.com/user-attachments/assets/b7ef93b0-6895-4fee-b728-a8fd3351fa96" />



# 🗣️ 리뷰 요구사항 (선택)
