### PR TITLE
[FEAT] 투표자 헤더 새 링크 만들기 기능 구현 및 UI 변경

### DIFF
--- a/src/app/meet/[meetingId]/ParticipantHeader.tsx
+++ b/src/app/meet/[meetingId]/ParticipantHeader.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-
 import { useDisclosure } from '@/shared/hooks/useDisclosure';
 import LinkShareBottomSheet from '@/shared/ui/bottom-sheet/LinkShareBottomSheet';
-import { Menu } from '@/shared/ui/menu';
+import RegisterSequenceBottomSheet from '@/shared/ui/bottom-sheet/RegisterSequenceBottomSheet';
 import { TopBar } from '@/shared/ui/top-bar';
 
 interface ParticipantHeaderProps {
@@ -18,7 +16,6 @@ export default function ParticipantHeader({
   url,
   className,
 }: ParticipantHeaderProps) {
-  const router = useRouter();
   const {
     isOpen: isShareOpen,
     open: openShare,
@@ -26,9 +23,9 @@ export default function ParticipantHeader({
   } = useDisclosure();
 
   const {
-    isOpen: isMenuOpen,
-    open: openMenu,
-    close: closeMenu,
+    isOpen: isRegisterOpen,
+    open: openRegister,
+    close: closeRegister,
   } = useDisclosure();
 
   return (
@@ -36,21 +33,22 @@ export default function ParticipantHeader({
       <div className={`relative ${className}`}>
         <TopBar
           title={title}
-          leftIcon='ic_hamburger'
-          onLeftClick={openMenu}
+          leftIcon='ic_calendar_add'
+          onLeftClick={openRegister}
           rightIcon='ic_other_share'
           onRightClick={openShare}
         />
-
-        <Menu isOpen={isMenuOpen} onClose={closeMenu} className='top-12 left-4'>
-          <Menu.Item onClick={() => router.push('/')}>모임 생성하기</Menu.Item>
-        </Menu>
       </div>
 
       <LinkShareBottomSheet
         isOpen={isShareOpen}
         onClose={closeShare}
         url={url}
+      />
+
+      <RegisterSequenceBottomSheet
+        isOpen={isRegisterOpen}
+        onClose={closeRegister}
       />
     </>
   );

--- a/src/shared/assets/icons/IcCalendarAdd.tsx
+++ b/src/shared/assets/icons/IcCalendarAdd.tsx
@@ -1,0 +1,37 @@
+import type { HTMLAttributes } from 'react';
+
+export default function IcCalendarAdd(props: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className='relative h-full w-full'
+      data-name='ic_calendar_add'
+      {...props}
+    >
+      <div className='absolute top-[12.5%] right-[8.33%] bottom-[8.33%] left-[16.67%]'>
+        <div
+          className='absolute inset-[-3.95%_-4.17%]'
+          style={{ '--stroke-0': 'currentColor' } as React.CSSProperties}
+        >
+          <svg
+            preserveAspectRatio='none'
+            width='100%'
+            height='100%'
+            viewBox='0 0 19.5 20.5'
+            fill='none'
+            xmlns='http://www.w3.org/2000/svg'
+            className='block size-full max-w-none'
+          >
+            <path
+              id='Vector'
+              d='M9.25 18.75H2.75C2.21957 18.75 1.71086 18.5393 1.33579 18.1642C0.960714 17.7891 0.75 17.2804 0.75 16.75V4.75C0.75 4.21957 0.960714 3.71086 1.33579 3.33579C1.71086 2.96071 2.21957 2.75 2.75 2.75H14.75C15.2804 2.75 15.7891 2.96071 16.1642 3.33579C16.5393 3.71086 16.75 4.21957 16.75 4.75V9.75M12.75 0.75V4.75M4.75 0.75V4.75M0.75 8.75H16.75M12.75 16.75H18.75M15.75 13.75V19.75'
+              stroke='var(--stroke-0, #191F28)'
+              strokeWidth='1.5'
+              strokeLinecap='round'
+              strokeLinejoin='round'
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/assets/icons/index.ts
+++ b/src/shared/assets/icons/index.ts
@@ -2,6 +2,7 @@ import ArrowDown from './ArrowDown';
 import ArrowNext from './ArrowNext';
 import ArrowPrev from './ArrowPrev';
 import ArrowUp from './ArrowUp';
+import IcCalendarAdd from './IcCalendarAdd';
 import IcCheckboxChecked from './IcCheckboxChecked';
 import IcCheckboxDefault from './IcCheckboxDefault';
 import IcCircleCheckFilled from './IcCircleCheckFilled';
@@ -22,6 +23,7 @@ export const icons = {
   arrow_next: ArrowNext,
   arrow_prev: ArrowPrev,
   arrow_up: ArrowUp,
+  ic_calendar_add: IcCalendarAdd,
   ic_circle_check_filled: IcCircleCheckFilled,
   ic_circle_check_outline: IcCircleCheckOutline,
   ic_circle_x_filled: IcCircleXFilled,

--- a/src/shared/ui/bottom-sheet/RegisterSequenceBottomSheet.tsx
+++ b/src/shared/ui/bottom-sheet/RegisterSequenceBottomSheet.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import BottomSheet from '@/shared/ui/bottom-sheet/BottomSheet';
+import Button from '@/shared/ui/button/Button';
+
+interface RegisterSequenceBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function RegisterSequenceBottomSheet({
+  isOpen,
+  onClose,
+}: RegisterSequenceBottomSheetProps) {
+  const router = useRouter();
+
+  const handleCreateNewLink = () => {
+    router.push('/');
+  };
+
+  return (
+    <BottomSheet isOpen={isOpen} onClose={onClose}>
+      <div className='flex flex-col items-center px-5 pt-2 pb-5 text-center'>
+        <h2 className='text-headline-5 mb-1 text-gray-900'>
+          새로운 투표 링크를 만드시겠어요?
+        </h2>
+        <p className='text-body-2 mb-8 text-gray-500'>
+          다른 모임 투표 링크가 생성돼요
+        </p>
+
+        <div className='flex w-full gap-3'>
+          <Button
+            fullWidth
+            onClick={onClose}
+            className='border border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+          >
+            취소
+          </Button>
+          <Button
+            fullWidth
+            onClick={handleCreateNewLink}
+            className='bg-gray-800 text-white hover:bg-gray-700'
+          >
+            새 링크 만들기
+          </Button>
+        </div>
+      </div>
+    </BottomSheet>
+  );
+}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #82

# 📝 작업 내용
1. Asset 추가
IcCalendarAdd
 아이콘 추가: Figma 디자인에 맞춘 캘린더 추가 SVG 아이콘 컴포넌트를 생성하고 src/shared/assets/icons에 등록.

2. UI Component 구현
RegisterSequenceBottomSheet 추가:
"새로운 투표 링크를 만드시겠어요?" 라는 문구와 함께 새로운 링크 생성 의사를 묻는 바텀 시트를 구현.
새 링크 만들기: 클릭 시 메인 페이지(/)로 이동하여 새로운 모임을 생성할 수 있도록 라우팅 처리.
취소: 바텀 시트를 닫습니다.
기존 BottomSheet 공통 컴포넌트와 Button 컴포넌트를 재사용하여 일관된 디자인을 적용.
<img width="375" height="812" alt="image" src="https://github.com/user-attachments/assets/ba4e60df-8e19-4a09-8e21-0b9f24aebaed" />


3. Feature Logic 수정 (ParticipantHeader)
좌측 아이콘 변경: 기존 햄버거 메뉴(ic_hamburger)를 ic_calendar_add로 교체.
인터랙션 변경:
기존: 햄버거 메뉴 클릭 시 메뉴 드롭다운 노출.
변경: 캘린더 추가 아이콘 클릭 시 RegisterSequenceBottomSheet 오픈.
불필요한 코드 제거: 사용하지 않는 Menu 컴포넌트 및 관련 로직을 제거.
