### PR TITLE
[FEAT] 모임 카드 컴포넌트 구현

### DIFF
--- a/apps/weddin/src/app/globals.css
+++ b/apps/weddin/src/app/globals.css
@@ -514,3 +514,163 @@
     animation: slide-down 0.3s ease-out forwards;
   }
 }
+/* Library Overrides */
+
+/* React Calendar Removed */
+
+/* React Datepicker overrides for cleaner look */
+/* Fluid Datepicker Layout */
+.react-datepicker {
+  background-color: white !important;
+  font-family: inherit !important;
+  border: none !important;
+  width: 100% !important; /* Fill container */
+  display: flex !important;
+  flex-direction: column;
+}
+.react-datepicker__month-container {
+  width: 100% !important;
+}
+.react-datepicker__header {
+  background-color: white !important;
+  border-bottom: none !important;
+  padding-top: 10px !important;
+}
+.react-datepicker__month {
+  margin: 0 !important;
+  display: flex;
+  flex-direction: column;
+  gap: 0; /* Adjust if vertical gap needed */
+}
+
+/* Hide screen reader only text visually */
+.react-datepicker__sr-only,
+.react-datepicker__aria-live {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+.react-datepicker__week,
+.react-datepicker__day-names {
+  display: flex !important;
+  justify-content: space-between;
+  width: 100% !important;
+}
+.react-datepicker__day-name,
+.react-datepicker__day-name span {
+  font-family: var(--font-pretendard) !important;
+  font-weight: 500 !important;
+  font-size: 14px !important;
+  line-height: 20px !important;
+  letter-spacing: -0.02em !important;
+  color: #64748b !important;
+  flex: 1 !important; /* Distribute evenly */
+  width: auto !important;
+  line-height: 2.5rem !important; /* Mobile friendly height */
+  margin: 0 !important;
+  text-align: center;
+}
+@media (min-width: 640px) {
+  .react-datepicker__day-name {
+    line-height: 54px !important;
+  }
+}
+.react-datepicker__triangle {
+  display: none;
+}
+.react-datepicker__day {
+  flex: 1 !important; /* Distribute evenly */
+  width: auto !important;
+  height: auto !important;
+  aspect-ratio: 1 / 1; /* Keep square */
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
+  margin: 0 !important;
+}
+/* Disable default keyboard selected style to avoid ugly outline */
+.react-datepicker__day:focus {
+  outline: none;
+}
+.react-datepicker__day:hover {
+  background-color: transparent !important;
+}
+.react-datepicker__day--selected,
+.react-datepicker__day--keyboard-selected {
+  background-color: transparent !important;
+  color: inherit !important;
+}
+.react-datepicker__day--today {
+  font-weight: normal !important; /* Reset bold if any */
+}
+
+/* Host Range Selector 전용 스타일 */
+.react-datepicker-wrapper-custom .react-datepicker__month-container {
+  width: 100%;
+}
+
+/* 모든 날짜 셀에 투명 테두리 기본 적용 (선택 시 크기 변화 방지) */
+.react-datepicker-wrapper-custom .react-datepicker__day {
+  /* border: 8px solid transparent !important; -> Removed in favor of gap logic in component */
+  box-sizing: border-box !important;
+}
+
+/* 비활성화됨 */
+.react-datepicker-wrapper-custom .react-datepicker__day--disabled {
+  color: #d1d5db !important;
+  cursor: not-allowed;
+  background: transparent !important;
+}
+
+/* 호버 상태 - now handled by component logic generally, keeping valid date hover just in case */
+.react-datepicker-wrapper-custom
+  .react-datepicker__day:not(.react-datepicker__day--disabled):hover {
+  background-color: transparent !important; /* Let component handle bg */
+}
+
+/* 기본 선택 클래스 동작 초기화 */
+.react-datepicker-wrapper-custom .react-datepicker__day--selected,
+.react-datepicker-wrapper-custom .react-datepicker__day--keyboard-selected {
+  background-color: transparent;
+  color: inherit;
+}
+
+@layer utilities {
+  @keyframes slide-down {
+    from {
+      transform: translateY(-100%);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+
+  .animate-toast-slide-down {
+    animation: slide-down 0.3s ease-out forwards;
+  }
+}
+
+/* Meeting Calendar overrides - taller cells for labels */
+.meeting-calendar-wrapper .react-datepicker__day {
+  height: 80px !important;
+  aspect-ratio: auto !important;
+  align-items: flex-start !important;
+}
+
+.meeting-calendar-wrapper .react-datepicker__day-name {
+  height: 36px !important;
+  line-height: 36px !important;
+  color: #4b4646 !important;
+}
+
+.meeting-calendar-wrapper .react-datepicker__day--outside-month {
+  opacity: 0.3 !important;
+}

--- a/apps/weddin/src/features/meeting-card/model/types.ts
+++ b/apps/weddin/src/features/meeting-card/model/types.ts
@@ -1,0 +1,13 @@
+export type MeetingCardData = {
+  id: string;
+  title: string;
+  dDay: number; // e.g., 2 means "D-2"
+  currentVotes: number;
+  totalVotes: number;
+  topDate: string; // e.g., "1월 29일 토요일"
+};
+
+export type MeetingCardProps = {
+  meeting: MeetingCardData;
+  className?: string;
+};

--- a/apps/weddin/src/features/meeting-card/ui/MeetingCard.stories.tsx
+++ b/apps/weddin/src/features/meeting-card/ui/MeetingCard.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import MeetingCard from './MeetingCard';
+
+const meta: Meta<typeof MeetingCard> = {
+  title: 'Features/MeetingCard',
+  component: MeetingCard,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof MeetingCard>;
+
+export const Default: Story = {
+  args: {
+    meeting: {
+      id: 'card1',
+      title: '관악구 쩝쩝박사 모임',
+      dDay: 3,
+      currentVotes: 4,
+      totalVotes: 6,
+      topDate: '2월 18일 토요일',
+    },
+  },
+};
+
+export const ZeroVotes: Story = {
+  args: {
+    meeting: {
+      id: 'card2',
+      title: '새로운 모임',
+      dDay: 10,
+      currentVotes: 0,
+      totalVotes: 5,
+      topDate: '미정',
+    },
+  },
+};

--- a/apps/weddin/src/features/meeting-card/ui/MeetingCard.tsx
+++ b/apps/weddin/src/features/meeting-card/ui/MeetingCard.tsx
@@ -1,0 +1,77 @@
+import Chip from '@repo/shared/ui/chip/Chip';
+import Icon from '@repo/shared/ui/icon/Icon';
+
+import { cn } from '@/shared/lib/utils';
+
+import type { MeetingCardProps } from '../model/types';
+
+export default function MeetingCard({ meeting, className }: MeetingCardProps) {
+  const { title, dDay, currentVotes, totalVotes, topDate } = meeting;
+  const progressPercent =
+    totalVotes > 0 ? (currentVotes / totalVotes) * 100 : 0;
+
+  return (
+    <div
+      className={cn(
+        'flex w-full flex-col gap-2 rounded-[12px] bg-white p-3 shadow-[0px_0px_30px_0px_rgba(0,0,0,0.04)]',
+        className,
+      )}
+    >
+      {/* Top section: D-day chip + title + arrow */}
+      <div className='flex flex-col gap-3'>
+        <div className='flex w-full items-start justify-between'>
+          <div className='flex min-w-0 flex-1 items-center gap-2'>
+            {/* D-day chip - Override colors to match Figma (gray-700) */}
+            <Chip
+              variant='line'
+              size='sm'
+              selected
+              selectable={false}
+              text={`D-${dDay}`}
+              className='border-gray-700! bg-gray-700! text-white!'
+            />
+
+            {/* Meeting title */}
+            <p className='text-title-7 min-w-0 flex-1 text-gray-900'>{title}</p>
+          </div>
+
+          {/* Arrow icon */}
+          <Icon
+            name='arrow_next'
+            size={20}
+            className='shrink-0 text-gray-400'
+          />
+        </div>
+
+        {/* Progress bar + vote count */}
+        <div className='flex w-full items-center justify-between gap-2'>
+          {/* Progress bar */}
+          <div className='h-3 flex-1 overflow-hidden rounded-[9px] bg-gray-100'>
+            <div
+              className='h-full rounded-[9px] bg-linear-to-r from-red-300 to-[#ff8094]'
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+
+          {/* Vote count */}
+          <p className='text-body-5 text-text-tertiary shrink-0'>
+            <span className='text-primary-subtle'>{currentVotes}</span>
+            <span>/{totalVotes}</span>
+          </p>
+        </div>
+      </div>
+
+      {/* Bottom section: Top date info */}
+      <div className='flex items-center gap-1.5 rounded-lg bg-gray-50 p-2'>
+        <div className='flex items-center'>
+          <Icon name='ic_flame' size={18} className='text-gray-300' />
+          <span className='text-body-5 text-text-tertiary'>유력 날짜</span>
+        </div>
+        <span className='text-body-5 text-gray-200'>|</span>
+        <span className='text-body-5 text-text-primary font-semibold'>
+          {topDate}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/shared/assets/icons/IcFlame.tsx
+++ b/packages/shared/assets/icons/IcFlame.tsx
@@ -1,0 +1,21 @@
+import type { SVGProps } from 'react';
+
+export default function IcFlame(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      viewBox='0 0 18 18'
+      fill='none'
+      {...props}
+    >
+      <path
+        d='M9 8.67647C10.3333 6.76118 9 4.14706 8.33333 3.5C8.33333 5.46576 7.15133 6.56771 6.33333 7.38235C5.516 8.19765 5 9.47882 5 10.6176C5 11.6473 5.42143 12.6348 6.17157 13.3629C6.92172 14.091 7.93913 14.5 9 14.5C10.0609 14.5 11.0783 14.091 11.8284 13.3629C12.5786 12.6348 13 11.6473 13 10.6176C13 9.62635 12.296 8.06824 11.6667 7.38235C10.476 9.32353 9.806 9.32353 9 8.67647Z'
+        fill='currentColor'
+        stroke='currentColor'
+        strokeWidth='1.125'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  );
+}

--- a/packages/shared/assets/icons/iconRegistry.ts
+++ b/packages/shared/assets/icons/iconRegistry.ts
@@ -9,6 +9,7 @@ import IcCircleCheckFilled from './IcCircleCheckFilled';
 import IcCircleCheckOutline from './IcCircleCheckOutline';
 import IcCircleXFilled from './IcCircleXFilled';
 import IcCircleXOutline from './IcCircleXOutline';
+import IcFlame from './IcFlame';
 import IcHamburger from './IcHamburger';
 import IcInfoFilled from './IcInfoFilled';
 import IcInfoOutline from './IcInfoOutline';
@@ -24,10 +25,14 @@ export const icons = {
   arrow_prev: ArrowPrev,
   arrow_up: ArrowUp,
   ic_calendar_add: IcCalendarAdd,
+
+  ic_checkbox_checked: IcCheckboxChecked,
+  ic_checkbox_default: IcCheckboxDefault,
   ic_circle_check_filled: IcCircleCheckFilled,
   ic_circle_check_outline: IcCircleCheckOutline,
   ic_circle_x_filled: IcCircleXFilled,
   ic_circle_x_outline: IcCircleXOutline,
+  ic_flame: IcFlame,
   ic_hamburger: IcHamburger,
   ic_info_filled: IcInfoFilled,
   ic_info_outline: IcInfoOutline,
@@ -36,8 +41,6 @@ export const icons = {
   ic_other_share: IcOtherShare,
   ic_people: IcPeople,
   ic_refresh: IcRefresh,
-  ic_checkbox_checked: IcCheckboxChecked,
-  ic_checkbox_default: IcCheckboxDefault,
 } as const;
 
 export type IconName = keyof typeof icons;

--- a/packages/shared/ui/chip/Chip.tsx
+++ b/packages/shared/ui/chip/Chip.tsx
@@ -57,31 +57,27 @@ export default function Chip({
 
   if (variant === 'line') {
     if (selected) {
-      colorStyles = 'bg-gray-800 border-gray-800 text-white hover:bg-gray-900';
+      colorStyles = 'bg-gray-800 border-gray-800 text-white';
     } else {
-      // 선택되지 않았을 때
       if (selectable) {
-        // 선택 가능하면 기본적으로 secondary, hover시 primary
         colorStyles =
-          'bg-gray-0 border-line-nonclickable text-text-secondary hover:text-text-primary hover:bg-gray-50';
+          'bg-white border-gray-100 text-text-primary hover:border-gray-200 transition-colors';
       } else {
-        // 선택 불가능하면 기본적으로 primary (강조됨)
-        colorStyles = 'bg-gray-0 border-line-nonclickable text-text-primary';
+        colorStyles = 'bg-white border-gray-100 text-text-primary';
       }
     }
   } else {
-    // Fill
+    // Fill Variant
     if (selected) {
-      // Hover brightness for 'main color' effect
+      // Fill Selected: bg-gray-900, text-white
       colorStyles =
-        'bg-primary-default border-transparent text-text-inverse hover:brightness-95';
+        'bg-gray-900 border-transparent text-white hover:brightness-95';
     } else {
       if (selectable) {
         colorStyles =
-          'bg-gray-100 border-transparent text-text-secondary hover:text-text-primary hover:bg-gray-200';
+          'bg-gray-100 border-transparent text-text-primary hover:bg-gray-700 hover:text-white transition-colors';
       } else {
-        colorStyles =
-          'bg-gray-100 border-transparent text-text-primary hover:bg-gray-200';
+        colorStyles = 'bg-gray-100 border-transparent text-text-primary';
       }
     }
   }

--- a/packages/shared/ui/chip/Chip.tsx
+++ b/packages/shared/ui/chip/Chip.tsx
@@ -41,15 +41,15 @@ export default function Chip({
   ...props
 }: ChipProps) {
   // 기본 스타일
-  const baseStyles = `relative flex shrink-0 items-center justify-center whitespace-nowrap rounded-[--radius-chip] border transition-colors ${
+  const baseStyles = `relative flex shrink-0 items-center justify-center whitespace-nowrap border transition-colors ${
     selectable ? 'cursor-pointer' : 'cursor-default'
   }`;
 
-  // 크기별 스타일 (Height, Padding, Typography)
+  // 크기별 스타일 (Height, Padding, Typography, Radius)
   const sizeStyles = {
-    xs: 'text-caption-7 px-2 py-0.5',
-    sm: 'text-body-5 px-2 py-1',
-    md: 'text-body-4 px-3 py-1.5',
+    xs: 'text-caption-7 px-2 py-0.5 rounded-[4px]',
+    sm: 'text-body-5 px-2 py-1 rounded-[6px]',
+    md: 'text-body-4 px-3 py-1.5 rounded-[6px]',
   };
 
   // 변형(Variant) 및 선택(Selected) 상태에 따른 색상 스타일


### PR DESCRIPTION
# 🚩 연관 이슈

closed #102

# 📝 작업 내용
작업 사항
1. MeetingCard
파일 경로: apps/weddin/src/features/meeting-card/ui/MeetingCard.tsx
주요 기능:
D-day 및 제목 표시: 상단에 D-day 칩과 모임 제목을 배치했습니다.
투표 진행 상황 시각화: 전체 인원 대비 현재 투표 인원을 프로그레스 바(그라데이션 효과 적용)로 시각화했습니다.
유력 날짜 안내: 화염 아이콘(ic_flame)과 함께 현재 가장 유력한 날짜를 하단에 강조 표시했습니다.

2. Chip 컴포넌트 스타일 리팩토링
파일 경로: packages/shared/ui/chip/Chip.tsx
변경 내용:
Border Radius: 기존 CSS 변수(--radius-chip) 대신 사이즈(xs, sm, md)별로 구체적인 값(4px, 6px)을 적용했습니다.
Color Styles: Figma 디자인(Node 99-222)에 맞춰 색상 스타일을 변경했습니다.

# 🗣️ 리뷰 요구사항 (선택)
