### PR TITLE
[FEAT] 메모 컴포넌트 구현

### DIFF
--- a/apps/weddin/src/features/meeting-memo/model/useMeetingMemo.ts
+++ b/apps/weddin/src/features/meeting-memo/model/useMeetingMemo.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type UseMeetingMemoOptions = {
+  initialValue?: string;
+  maxLength?: number;
+  onSave?: (value: string) => void;
+  debounceMs?: number;
+};
+
+export default function useMeetingMemo({
+  initialValue = '',
+  maxLength = 200,
+  onSave,
+  debounceMs = 500,
+}: UseMeetingMemoOptions) {
+  const [value, setValue] = useState(initialValue);
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isFirstRender = useRef(true);
+
+  const charCount = value.length;
+
+  const handleChange = useCallback(
+    (newValue: string) => {
+      if (newValue.length > maxLength) {
+        return;
+      }
+      setValue(newValue);
+    },
+    [maxLength],
+  );
+
+  // Debounced auto-save
+  useEffect(() => {
+    // Skip initial render
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    timerRef.current = setTimeout(() => {
+      onSave?.(value);
+      setLastSavedAt(new Date());
+    }, debounceMs);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [value, debounceMs, onSave]);
+
+  const formattedSaveTime = lastSavedAt
+    ? `${String(lastSavedAt.getHours()).padStart(2, '0')}:${String(lastSavedAt.getMinutes()).padStart(2, '0')} 저장됨`
+    : null;
+
+  return {
+    value,
+    charCount,
+    maxLength,
+    lastSavedAt,
+    formattedSaveTime,
+    handleChange,
+  };
+}

--- a/apps/weddin/src/features/meeting-memo/ui/MeetingMemo.stories.tsx
+++ b/apps/weddin/src/features/meeting-memo/ui/MeetingMemo.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useState } from 'react';
+
+import MeetingMemo from './MeetingMemo';
+
+const meta: Meta<typeof MeetingMemo> = {
+  title: 'Features/MeetingMemo',
+  component: MeetingMemo,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof MeetingMemo>;
+
+export const Default: Story = {
+  args: {
+    initialValue: '',
+    maxLength: 200,
+  },
+};
+
+export const WithInitialValue: Story = {
+  args: {
+    initialValue: '기본 메모 내용입니다.',
+    maxLength: 200,
+  },
+};
+
+export const Interactive: Story = {
+  render: (args) => {
+    const [val, setVal] = useState(args.initialValue || '');
+    return (
+      <MeetingMemo
+        {...args}
+        initialValue={val}
+        onSave={(v) => {
+          console.log('saved', v);
+          setVal(v);
+        }}
+      />
+    );
+  },
+};

--- a/apps/weddin/src/features/meeting-memo/ui/MeetingMemo.tsx
+++ b/apps/weddin/src/features/meeting-memo/ui/MeetingMemo.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import Icon from '@repo/shared/ui/icon/Icon';
+
+import { cn } from '@/shared/lib/utils';
+
+import useMeetingMemo from '../model/useMeetingMemo';
+
+type MeetingMemoProps = {
+  initialValue?: string;
+  onSave?: (value: string) => void;
+  maxLength?: number;
+  className?: string;
+};
+
+export default function MeetingMemo({
+  initialValue = '',
+  onSave,
+  maxLength = 200,
+  className,
+}: MeetingMemoProps) {
+  const { value, charCount, formattedSaveTime, handleChange } = useMeetingMemo({
+    initialValue,
+    maxLength,
+    onSave,
+  });
+
+  return (
+    <div
+      className={cn(
+        'flex w-full items-center rounded-xl bg-white p-5 shadow-[0px_0px_30px_0px_rgba(0,0,0,0.04)]',
+        className,
+      )}
+    >
+      <div className='flex flex-1 flex-col gap-2'>
+        {/* Title */}
+        <div className='flex flex-col items-start'>
+          <p className='text-title-6 text-text-primary'>메모</p>
+        </div>
+
+        {/* Textarea + Footer */}
+        <div className='flex w-full flex-col gap-1'>
+          {/* Textarea */}
+          <div className='flex h-30.25 w-full items-start justify-between rounded-lg border border-gray-100 bg-white px-3.5 py-3'>
+            <textarea
+              className='text-body-4 text-text-primary placeholder:text-text-quaternary h-full w-full resize-none bg-transparent outline-none'
+              placeholder='모임에서 만나는 장소, 음식 등을 메모해보세요.'
+              value={value}
+              onChange={(e) => handleChange(e.target.value)}
+              maxLength={maxLength}
+            />
+          </div>
+
+          {/* Footer: Save indicator + Char counter */}
+          <div className='flex w-full items-center justify-between'>
+            {/* Save indicator */}
+            <div className='flex items-center gap-0.5'>
+              {formattedSaveTime ? (
+                <>
+                  <Icon
+                    name='ic_check'
+                    size={16}
+                    className='text-text-tertiary'
+                  />
+
+                  <p className='text-body-5 text-text-tertiary'>
+                    {formattedSaveTime}
+                  </p>
+                </>
+              ) : null}
+            </div>
+
+            {/* Character counter */}
+            <p className='text-body-5 text-text-quaternary'>
+              {charCount}/{maxLength}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/shared/assets/icons/IcCheck.tsx
+++ b/packages/shared/assets/icons/IcCheck.tsx
@@ -1,0 +1,27 @@
+import type { HTMLAttributes } from 'react';
+
+export default function IcCheck(props: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className='relative h-full w-full' data-name='ic_check' {...props}>
+      <div className='absolute inset-[29.17%_16.67%_29.17%_20.83%]'>
+        <svg
+          preserveAspectRatio='none'
+          width='100%'
+          height='100%'
+          viewBox='0 0 16.5 11.5'
+          fill='none'
+          xmlns='http://www.w3.org/2000/svg'
+          className='block size-full max-w-none'
+        >
+          <path
+            d='M0.75 5.75L5.75 10.75L15.75 0.75'
+            stroke='currentColor'
+            strokeWidth='1.5'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+          />
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/packages/shared/assets/icons/iconRegistry.ts
+++ b/packages/shared/assets/icons/iconRegistry.ts
@@ -3,6 +3,7 @@ import ArrowNext from './ArrowNext';
 import ArrowPrev from './ArrowPrev';
 import ArrowUp from './ArrowUp';
 import IcCalendarAdd from './IcCalendarAdd';
+import IcCheck from './IcCheck';
 import IcCheckboxChecked from './IcCheckboxChecked';
 import IcCheckboxDefault from './IcCheckboxDefault';
 import IcCircleCheckFilled from './IcCircleCheckFilled';
@@ -24,6 +25,7 @@ export const icons = {
   arrow_prev: ArrowPrev,
   arrow_up: ArrowUp,
   ic_calendar_add: IcCalendarAdd,
+  ic_check: IcCheck,
   ic_circle_check_filled: IcCircleCheckFilled,
   ic_circle_check_outline: IcCircleCheckOutline,
   ic_circle_x_filled: IcCircleXFilled,


### PR DESCRIPTION
# 🚩 연관 이슈

closed #

# 📝 작업 내용
모임 상세 페이지에서 사용할 메모 컴포넌트를 구현했습니다.

1. ic_check 아이콘 추가
Figma 디자인 시스템의 체크마크 아이콘(ic_check)을 공통 아이콘 패키지에 추가
packages/shared/assets/icons/IcCheck.tsx생성
iconRegistry.ts에 ic_check으로 등록

2. 메모 컴포넌트 구현
MeetingMemo.tsx: 메모 UI 컴포넌트
제목, 텍스트 입력 영역, 저장 표시, 글자 수 카운터로 구성
className prop을 통한 외부 스타일 확장 지원

useMeetingMemo.ts: 메모 비즈니스 로직 훅
디바운스 자동 저장 (500ms) — 입력이 멈추면 자동으로 onSave 콜백 호출
최대 글자 수 제한 (maxLength, 기본 200자)
마지막 저장 시각 표시 (예: 17:30 저장됨)

3. 스토리북 추가
MeetingMemo.stories.tsx 작성
Default, WithInitialValue, Interactive 3가지 스토리 제공

# 🗣️ 리뷰 요구사항 (선택)
