### PR TITLE
feat/#111 모임 생성 시, 직접 투표하기 선택 시, 바로 날짜 선택으로 이동

### DIFF
--- a/src/features/meet-create-date/model/useDateSelect.ts
+++ b/src/features/meet-create-date/model/useDateSelect.ts
@@ -57,7 +57,11 @@ export function useDateSelect(hostName: string, meetingName: string) {
       selection: 'direct_vote',
     });
     if (createdMeetingId) {
-      router.replace(`/meet/${createdMeetingId}/register`);
+      const params = new URLSearchParams();
+      params.set('name', hostName);
+      router.replace(
+        `/meet/${createdMeetingId}/register/date?${params.toString()}`,
+      );
     }
   };
 


### PR DESCRIPTION
# 🚩 연관 이슈

closed #111

# 📝 작업 내용

- 모임 생성 시 "직접 투표하기"를 선택한 경우, 기존에는 `/meet/{id}/register` 페이지로 이동했으나, 바로 날짜 선택 페이지(`/meet/{id}/register/date`)로 이동하도록 변경
- 호스트 이름을 쿼리 파라미터(`name`)로 전달하여 날짜 선택 페이지에서 활용할 수 있도록 처리

# 🗣️ 리뷰 요구사항 (선택)