### PR TITLE
design/#123 dropdown 배경 그라디언트 open/closed 상태별 분리

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -641,4 +641,24 @@
   .animate-toast-slide-down {
     animation: slide-down 0.3s ease-out forwards;
   }
+
+  .bg-dropdown-gradient-open {
+    background-image:
+      linear-gradient(
+        4.45deg,
+        rgba(255, 255, 255, 0) 7.66%,
+        var(--color-primary-subtlest) 93.2%
+      ),
+      linear-gradient(90deg, #ffffff 0%, #ffffff 100%);
+  }
+
+  .bg-dropdown-gradient-closed {
+    background-image:
+      linear-gradient(
+        1.62deg,
+        rgba(255, 255, 255, 0) 7.66%,
+        var(--color-primary-subtlest) 93.2%
+      ),
+      linear-gradient(90deg, #ffffff 0%, #ffffff 100%);
+  }
 }

--- a/src/shared/ui/dropdown/Dropdown.tsx
+++ b/src/shared/ui/dropdown/Dropdown.tsx
@@ -30,7 +30,9 @@ export default function Dropdown({
 
   return (
     <div ref={containerRef} className={`font-pretendard w-full ${className}`}>
-      <div className='border-primary-subtler rounded-[--radius-dropdown] border bg-[linear-gradient(0deg,rgba(255,255,255,0)_7.66%,var(--color-primary-subtlest)_93.19%),var(--color-gray-0)] shadow-[0_0_30px_0_rgba(0,0,0,0.04)]'>
+      <div
+        className={`border-primary-subtler rounded-(--radius-dropdown) border shadow-[0_0_30px_0_rgba(0,0,0,0.04)] ${isOpen ? 'bg-dropdown-gradient-open' : 'bg-dropdown-gradient-closed'}`}
+      >
         {/* Header (Trigger) */}
         <button
           type='button'


### PR DESCRIPTION
# 🚩 연관 이슈

closed #123

# 📝 작업 내용

## 🎨 어떤 변경인가요?

Dropdown 컴포넌트의 배경 그라디언트를 open/closed 상태에 따라 다른 각도로 적용했습니다.

기존
<img width="663" height="75" alt="image" src="https://github.com/user-attachments/assets/5d2f5eaf-f00b-4005-8ac9-72fe830e254d" />


변경
<img width="663" height="75" alt="image" src="https://github.com/user-attachments/assets/356f9ab8-b198-4bfb-a66b-52dc298b4a5c" />


## ✅ 어떻게 변경했나요?

### 1. `globals.css`에 유틸리티 클래스 추가

```css
.bg-dropdown-gradient-open {
  background-image:
    linear-gradient(4.45deg, rgba(255, 255, 255, 0) 7.66%, var(--color-primary-subtlest) 93.2%),
    linear-gradient(90deg, #ffffff 0%, #ffffff 100%);
}

.bg-dropdown-gradient-closed {
  background-image:
    linear-gradient(1.62deg, rgba(255, 255, 255, 0) 7.66%, var(--color-primary-subtlest) 93.2%),
    linear-gradient(90deg, #ffffff 0%, #ffffff 100%);
}
```

open 상태는 `4.45deg`, closed 상태는 `1.62deg`로 각도를 다르게 적용해 시각적 차이를 줬습니다.

### 2. `Dropdown.tsx` 인라인 arbitrary value 제거

기존에 Tailwind arbitrary value(`bg-[linear-gradient(...)]`)로 작성된 정적 배경을 제거하고, `isOpen` 상태에 따라 위 유틸리티 클래스를 조건부 적용했습니다.

## 📁 변경 파일 요약

| 파일 | 변경 내용 |
|------|----------|
| `src/app/globals.css` | `bg-dropdown-gradient-open`, `bg-dropdown-gradient-closed` 유틸리티 클래스 추가 |
| `src/shared/ui/dropdown/Dropdown.tsx` | 조건부 그라디언트 클래스 적용 |

# 🗣️ 리뷰 요구사항 (선택)