### PR TITLE
feat/#131-time-range-picker time-range-picker

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -13,13 +13,12 @@
 - **shared/**: 도메인 비의존 공용 코드 (`ui/`, `lib/`, `hooks/`, `api/`, `config/`, `types/`).
 - **widgets/**: 여러 feature/shared를 조합한 섹션/블록 단위 UI (필요 시에만 생성).
 
-### II. Monorepo Structure
+### II. Project Structure
 
-npm workspaces 기반 모노레포로, 두 개의 Next.js 앱과 공유 패키지로 구성된다.
+단일 Next.js 앱 구조(`src/`)로 운영되는 moit 서비스다.
 
-- `apps/moit` — 모임 투표 서비스 (port 3000)
-- `apps/weddin` — 웨딩 서비스 (port 3001)
-- `packages/shared` — 앱 간 공유 컴포넌트/유틸 (`@repo/shared`)
+- `src/` — moit 서비스 (모임 투표, Next.js App Router, port 3000)
+- FSD 레이어(`app/`, `features/`, `entities/`, `shared/`, `widgets/`)는 모두 `src/` 하위에 위치한다.
 
 ### III. No Barrel Exports
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@ Auto-generated from all feature plans. Last updated: 2026-02-14
 
 ## Active Technologies
 
+- TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul (바텀 시트 후보), date-fns ^4.1.0 (feat/#131-time-range-picker)
+- TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul(바텀 시트 — `@/shared/ui/bottom-sheet/BottomSheet`에서 캡슐화), date-fns ^4.1.0, react-datepicker ^9.1.0(기존), ky(HTTP), zod(검증), Amplitude(analytics) (feat/#131-time-range-picker)
+- N/A — 클라이언트 상태만. 서버 저장은 `POST /v1/meeting` 바디에 직렬화된 `timeRange`로 단발 전송. (feat/#131-time-range-picker)
+
 - TypeScript 5 + React 19, Next.js 16 (App Router), react-datepicker ^9.1.0, date-fns ^4.1.0 (feat/#127-calendar-drag-path)
 
 - TypeScript 5 + React 19, Next.js 16 (App Router), react-datepicker, date-fns (feat/#118-date-click-race-fix)
@@ -28,10 +32,10 @@ TypeScript 5: Follow standard conventions
 
 ## Recent Changes
 
-- feat/#127-calendar-drag-path: Added TypeScript 5 + React 19, Next.js 16 (App Router), react-datepicker ^9.1.0, date-fns ^4.1.0
-- feat/#127-calendar-drag-path: Added [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
+- feat/#131-time-range-picker: Added TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul(바텀 시트 — `@/shared/ui/bottom-sheet/BottomSheet`에서 캡슐화), date-fns ^4.1.0, react-datepicker ^9.1.0(기존), ky(HTTP), zod(검증), Amplitude(analytics)
+- feat/#131-time-range-picker: Added TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul (바텀 시트 후보), date-fns ^4.1.0
 
-- feat/#121-mobile-viewport-height: Added TypeScript 5
+- feat/#127-calendar-drag-path: Added TypeScript 5 + React 19, Next.js 16 (App Router), react-datepicker ^9.1.0, date-fns ^4.1.0
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/specs/feat/131-time-range-picker/checklists/requirements.md
+++ b/specs/feat/131-time-range-picker/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Time Range Picker
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — 사용자 가치·요구 중심 기술 (재사용 가능한 컴포넌트 경로는 Assumptions에만 참고로 명시)
+- [x] Focused on user value and business needs — 날짜+시간 범위 설정을 통한 투표 피로도 감소
+- [x] Written for non-technical stakeholders — 시나리오·수용기준이 자연어로 기술됨
+- [x] All mandatory sections completed — Overview / User Scenarios / Requirements / Success Criteria / Assumptions
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous — 각 FR은 관찰 가능한 UI·요청 동작으로 기술
+- [x] Success criteria are measurable — 시간(60초), 비율(0%, 100%), 환경(iOS/Android/Chrome)
+- [x] Success criteria are technology-agnostic — 프레임워크·라이브러리 미언급
+- [x] All acceptance scenarios are defined — 4개 User Story 모두 Given/When/Then 시나리오 포함
+- [x] Edge cases are identified — 자정 교차, 동일 시각, 토글 토글, 작은 화면, 타임존
+- [x] Scope is clearly bounded — `maxParticipantCount` UI 제외, 타임존 변환 제외
+- [x] Dependencies and assumptions identified — 기존 `time-range-select` 피처, 공용 BottomSheet, 디자인 토큰
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria — FR-001~012 각각 시나리오/SC에 매핑 가능
+- [x] User scenarios cover primary flows — P1 3개(토글 OFF / 토글 ON / 범위 유효성) + P3 1개(테스트 페이지)
+- [x] Feature meets measurable outcomes defined in Success Criteria — SC-001~005
+- [x] No implementation details leak into specification — 구체 컴포넌트 이름은 Assumptions·Key Entities 안내로 제한
+
+## Notes
+
+- 이번 재작성은 Figma 확정 UI(node 3557:8685, 3561:35701)와 신규 요청 바디(`timeRange` 옵셔널 추가)에 맞춘 업데이트이다.
+- 기존 `src/features/time-range-select/` 구현을 최대한 재사용하고, Figma 스펙에 맞춘 스타일 정돈과 `/date` 페이지 통합이 핵심이다.
+- `maxParticipantCount` UI 입력은 별도 티켓에서 다룰 것.

--- a/specs/feat/131-time-range-picker/contracts/component-interface.md
+++ b/specs/feat/131-time-range-picker/contracts/component-interface.md
@@ -1,0 +1,115 @@
+# Component Interface Contract: Time Range Picker (v2 — Wheel UI)
+
+**이 피처는 백엔드 API를 직접 호출하지 않는다.**
+모든 계약은 React 컴포넌트 props/콜백 인터페이스로 정의된다.
+
+---
+
+## CONTRACT-001: TimeRangePicker 컴포넌트
+
+**위치**: `src/features/time-range-select/ui/TimeRangePicker.tsx`
+**역할**: "시간" 섹션 전체 — 시작시간/종료시간 행 표시 + 바텀 시트 통합 + 건너뛰기 체크박스
+
+### Props
+
+```typescript
+interface TimeRangePickerProps {
+  initialStartTime?: TimeValue; // 기본값: { hour: 9, minute: 0 }
+  initialEndTime?: TimeValue; // 기본값: { hour: 9, minute: 0 }
+  onComplete?: (range: { startTime: TimeValue; endTime: TimeValue }) => void;
+  onSkip?: () => void; // "시간 설정 안하고 넘어가기" 체크 시 호출
+}
+```
+
+### 동작 보장
+
+- 기본값은 `{ hour: 9, minute: 0 }`
+- 시작시간/종료시간 행 탭 → 바텀 시트에서 휠 피커 표시
+- 바텀 시트 "확인" 클릭 → 선택값 적용 후 시트 닫힘
+- `isValid` (endTime > startTime)일 때만 `onComplete` 호출
+
+---
+
+## CONTRACT-002: TimeWheelPicker 컴포넌트
+
+**위치**: `src/features/time-range-select/ui/TimeWheelPicker.tsx`
+**역할**: iOS 스타일 휠 피커 — 시 컬럼 + 콜론 + 분 컬럼
+
+### Props
+
+```typescript
+interface TimeWheelPickerProps {
+  value: TimeValue;
+  onChange: (value: TimeValue) => void;
+}
+```
+
+### 동작 보장
+
+- 시 컬럼: 0~23 스크롤 목록
+- 분 컬럼: [00, 30] 스크롤 목록
+- 중앙 선택 항목: 진한 텍스트 + 둥근 테두리 강조
+- ±1 항목: 중간 회색, ±2 항목: 연한 회색 (페이드 효과)
+- `scroll-snap-type: y mandatory` 스냅 동작
+- 스크롤 종료 후 onChange 호출
+
+---
+
+## CONTRACT-003: TimeWheelColumn 컴포넌트
+
+**위치**: `src/features/time-range-select/ui/TimeWheelColumn.tsx`
+**역할**: 단일 스크롤 휠 컬럼 (시 또는 분)
+
+### Props
+
+```typescript
+interface TimeWheelColumnProps {
+  items: number[];
+  value: number;
+  onChange: (value: number) => void;
+  formatItem?: (n: number) => string;
+}
+```
+
+### 동작 보장
+
+- `scroll-snap-type: y mandatory` 스냅
+- 스크롤 위치 기반 실시간 색상 페이드 (distance 0: 진함, 1: 회색, 2+: 연함)
+- 항목 탭 시 해당 항목으로 스크롤 이동
+- 스크롤바 숨김
+- 최소 탭 영역 44px
+
+---
+
+## CONTRACT-004: useTimeRangeSelect 훅
+
+**위치**: `src/features/time-range-select/model/useTimeRangeSelect.ts`
+
+(기존과 동일, 상세는 data-model.md 참조)
+
+---
+
+## CONTRACT-005: 순수 유틸 함수
+
+**위치**: `src/features/time-range-select/lib/timeUtils.ts`
+
+(기존과 동일, TDD 테스트 완료)
+
+---
+
+## 데이터 흐름
+
+```
+app/test/time-picker/page.tsx
+  └── TimeRangePicker (features/time-range-select/ui)
+        ├── useTimeRangeSelect (model)
+        │     ├── timeUtils.isValidTimeRange() (lib)
+        │     └── timeUtils.getEndTimeOptions() (lib)
+        ├── BottomSheet (shared/ui)
+        │     └── TimeWheelPicker (ui)
+        │           ├── TimeWheelColumn — 시(0~23)
+        │           └── TimeWheelColumn — 분(0, 30)
+        └── Checkbox (shared/ui)
+
+onComplete callback → 부모 컴포넌트 (테스트 페이지 state / 추후 meet-create)
+```

--- a/specs/feat/131-time-range-picker/contracts/create-meeting.md
+++ b/specs/feat/131-time-range-picker/contracts/create-meeting.md
@@ -1,0 +1,156 @@
+# API Contract: POST /v1/meeting (Time Range 확장)
+
+**Feature**: `feat/#131-time-range-picker`
+**Client**: `src/entities/meet/api/createMeeting.ts` (ky, baseURL 공용)
+**DTO**: `src/entities/meet/dto/meet.dto.ts` (zod)
+
+본 계약은 `createMeetRequestDto`의 확장과 서버 전송 바디 두 형태(토글 OFF / ON)를 규정한다. 엔드포인트·응답 스키마는 기존과 동일하다.
+
+---
+
+## Endpoint
+
+- **Method**: `POST`
+- **Path**: `v1/meeting`
+- **Auth**: 기존 방식 유지(서비스 공용 헤더).
+- **Content-Type**: `application/json`
+
+---
+
+## Request Body — 토글 OFF
+
+```json
+{
+  "title": "2월 스터디",
+  "hostName": "주최자",
+  "dates": ["2026-02-20", "2026-02-21"]
+}
+```
+
+- `timeRange` 필드가 **포함되지 않아야 한다**. (SC-004: 0%)
+- zod 스키마가 `timeRange`를 `.optional()`로 정의하므로 `parse()` 이후에도 키가 존재하지 않는다.
+
+---
+
+## Request Body — 토글 ON
+
+```json
+{
+  "title": "2월 스터디",
+  "hostName": "주최자",
+  "dates": ["2026-02-20", "2026-02-21"],
+  "timeRange": {
+    "startTime": "09:00",
+    "endTime": "12:00"
+  }
+}
+```
+
+- `startTime` / `endTime` 모두 정규식 `^([01]\d|2[0-3]):(00|30)$`에 매치되어야 한다.
+- `startTime < endTime` (사전식, leading zero 보장).
+
+---
+
+## Validation Schema (zod)
+
+```ts
+const TIME_PATTERN = /^([01]\d|2[0-3]):(00|30)$/;
+
+const timeRangeDto = z
+  .object({
+    startTime: z
+      .string()
+      .regex(TIME_PATTERN, '시각은 "HH:mm" 형식이어야 합니다.'),
+    endTime: z
+      .string()
+      .regex(TIME_PATTERN, '시각은 "HH:mm" 형식이어야 합니다.'),
+  })
+  .refine(({ startTime, endTime }) => startTime < endTime, {
+    message: 'endTime은 startTime보다 커야 합니다.',
+    path: ['endTime'],
+  });
+
+export const createMeetRequestDto = z.object({
+  title: z.string().min(1, '모임 이름은 필수입니다.'),
+  hostName: z.string().min(1, '모임장 이름은 필수입니다.'),
+  dates: z.array(z.string()).min(1, '날짜를 선택해주세요.'),
+  timeRange: timeRangeDto.optional(),
+});
+```
+
+---
+
+## Response
+
+기존과 동일.
+
+```json
+{
+  "id": "meet_01HZX..."
+}
+```
+
+```ts
+export const createMeetResponseDto = z.object({ id: z.string() });
+```
+
+`createMeeting.ts`는 응답을 `validateSchema({ dto, schema: createMeetResponseDto, schemaName: 'v1/meeting' })`로 검증한 뒤 `CreateMeetResponse`를 반환한다(변경 없음).
+
+---
+
+## Client Call Pattern
+
+```ts
+// features/meet-create-date/model/useDateSelect.ts
+const timeRangePayload: TimeRangePayload | undefined =
+  isTimeRangeEnabled && range
+    ? {
+        startTime: formatTime(range.startTime),
+        endTime: formatTime(range.endTime),
+      }
+    : undefined;
+
+trackEvent('host_create_meeting_cta_click', {
+  total_days: formattedDates.length,
+  time_range_enabled: Boolean(timeRangePayload),
+  start_time: timeRangePayload?.startTime,
+  end_time: timeRangePayload?.endTime,
+});
+
+const response = await createMeeting({
+  title: meetingName,
+  hostName,
+  dates: formattedDates,
+  timeRange: timeRangePayload, // undefined면 직렬화에서 제외
+});
+```
+
+---
+
+## Error Cases (클라이언트 기준)
+
+| 상황                            | 감지 방식                                    | 사용자 영향                                        |
+| ------------------------------- | -------------------------------------------- | -------------------------------------------------- |
+| 날짜 0개                        | CTA 비활성(선행 가드) + zod `dates.min(1)`   | 요청 미발송                                        |
+| `timeRange.startTime` 형식 위반 | UI 옵션이 30분 단위만 노출 + zod regex       | 요청 미발송                                        |
+| `startTime >= endTime`          | UI에서 옵션 disable + zod `refine`           | 요청 미발송, CTA 비활성(SC-003)                    |
+| 토글 OFF인데 `timeRange` 채워짐 | `isTimeRangeEnabled` 가드로 `undefined` 고정 | 해당 경로 발생 불가(SC-004)                        |
+| 네트워크/5xx                    | `api.post(...).json()` throw                 | 기존 패턴대로 `alert('모임 생성에 실패했습니다.')` |
+
+---
+
+## Test Plan (Vitest)
+
+1. `createMeetRequestDto.parse({...without timeRange})` → 성공, 결과 객체에 `timeRange` 키 없음.
+2. `createMeetRequestDto.parse({..., timeRange: { startTime: '09:00', endTime: '12:00' }})` → 성공.
+3. `timeRange: { startTime: '09:15', endTime: '12:00' }` → `regex` 실패.
+4. `timeRange: { startTime: '12:00', endTime: '09:00' }` → `refine` 실패.
+5. `timeRange: { startTime: '09:00', endTime: '09:00' }` → `refine` 실패(동일 시각).
+6. `timeRange: { startTime: '23:30', endTime: '24:00' }` → `regex` 실패(25시 이상 방어).
+
+---
+
+## Change Summary
+
+- 파일 `src/entities/meet/dto/meet.dto.ts`: `timeRangeDto` 추가 + `createMeetRequestDto`에 `timeRange.optional()` 필드 추가 + `TimeRangePayload` export.
+- 파일 `src/entities/meet/api/createMeeting.ts`: 코드 변경 없음(확장된 DTO를 통해 자동으로 검증·직렬화).

--- a/specs/feat/131-time-range-picker/data-model.md
+++ b/specs/feat/131-time-range-picker/data-model.md
@@ -1,0 +1,218 @@
+# Data Model: Time Range Picker (날짜 선택 페이지 통합)
+
+**Phase 1 출력** | Updated: 2026-04-20
+
+본 문서는 `/date` 페이지 통합 시점의 데이터 모델을 정의한다. feature 내부 런타임 타입(`TimeValue`/`TimeRange`)과 서버 전송 직렬화 타입(`TimeRangePayload`), `CreateMeetRequest` 확장을 한 자리에 모은다.
+
+---
+
+## 1. 런타임 타입 (feature 내부)
+
+위치: `src/features/time-range-select/model/types.ts` (기존 유지)
+
+```ts
+type Minute = 0 | 30;
+
+export interface TimeValue {
+  hour: number; // 0~23
+  minute: Minute;
+}
+
+export interface TimeRange {
+  startTime: TimeValue | null;
+  endTime: TimeValue | null;
+}
+
+export interface TimeOption {
+  value: TimeValue;
+  label: string; // "HH:mm"
+  isDisabled: boolean;
+}
+```
+
+### 불변식
+
+- `TimeValue.hour` ∈ `{0, …, 23}` 정수.
+- `TimeValue.minute` ∈ `{0, 30}` — 타입 레벨에서 강제.
+- 완성된 범위: `startTime !== null && endTime !== null`.
+- 유효한 범위: `timeToMinutes(endTime) > timeToMinutes(startTime)` (자정 교차 금지).
+
+---
+
+## 2. 서버 직렬화 타입
+
+위치: `src/entities/meet/dto/meet.dto.ts` (확장)
+
+```ts
+const TIME_PATTERN = /^([01]\d|2[0-3]):(00|30)$/;
+
+export const timeRangeDto = z
+  .object({
+    startTime: z
+      .string()
+      .regex(TIME_PATTERN, '시각은 "HH:mm" 형식이어야 합니다.'),
+    endTime: z
+      .string()
+      .regex(TIME_PATTERN, '시각은 "HH:mm" 형식이어야 합니다.'),
+  })
+  .refine(({ startTime, endTime }) => startTime < endTime, {
+    message: 'endTime은 startTime보다 커야 합니다.',
+    path: ['endTime'],
+  });
+
+export type TimeRangePayload = z.infer<typeof timeRangeDto>;
+// => { startTime: string; endTime: string }
+```
+
+### 불변식
+
+- 두 필드 모두 정규식 `^([01]\d|2[0-3]):(00|30)$` 매치.
+- `startTime < endTime` 사전식 비교(leading zero 보장).
+- `"HH:mm"` 라벨은 로컬 타임존 기준으로 해석되며, 타임존 변환은 없다.
+
+### 변환 규칙 (런타임 → 서버)
+
+```ts
+// src/features/time-range-select/lib/timeUtils.ts (기존)
+formatTime({ hour, minute }): string // => "HH:mm"
+
+// 호출 지점(features/meet-create-date/ui/DateSelectPage.tsx 근처)
+const payload: TimeRangePayload | undefined = isTimeRangeEnabled && range
+  ? { startTime: formatTime(range.startTime), endTime: formatTime(range.endTime) }
+  : undefined;
+```
+
+---
+
+## 3. `CreateMeetRequest` 확장
+
+위치: `src/entities/meet/dto/meet.dto.ts` (확장)
+
+```ts
+export const createMeetRequestDto = z.object({
+  title: z.string().min(1, '모임 이름은 필수입니다.'),
+  hostName: z.string().min(1, '모임장 이름은 필수입니다.'),
+  dates: z.array(z.string()).min(1, '날짜를 선택해주세요.'),
+  timeRange: timeRangeDto.optional(),
+});
+
+export type CreateMeetRequest = z.infer<typeof createMeetRequestDto>;
+// => {
+//   title: string;
+//   hostName: string;
+//   dates: string[];
+//   timeRange?: { startTime: string; endTime: string };
+// }
+```
+
+### 직렬화 동작
+
+- `timeRange`가 `undefined`이면 `createMeetRequestDto.parse()` 결과 객체에 키가 포함되지 않아 `JSON.stringify`에서 자연스럽게 누락된다 → 토글 OFF 시 body에 `timeRange` 필드가 존재하지 않음을 보장(SC-004).
+- `timeRange`가 존재하면 `refine` 단계에서 순서 불변식을 재검증한다(SC-003 보조 차단).
+
+---
+
+## 4. feature 상태 훅 (변경 없음)
+
+위치: `src/features/time-range-select/model/useTimeRangeSelect.ts` (유지)
+
+```ts
+useTimeRangeSelect({
+  initialStartTime?: TimeValue,
+  initialEndTime?: TimeValue,
+  onChange?: (range: { startTime: TimeValue; endTime: TimeValue }) => void,
+}): {
+  startTime: TimeValue | null;
+  endTime: TimeValue | null;
+  isComplete: boolean;
+  isValid: boolean;
+  handleStartTimeChange(v: TimeValue): void;
+  handleEndTimeChange(v: TimeValue): void;
+  endTimeOptions: TimeOption[];
+  allSlots: TimeValue[];
+}
+```
+
+동작 규칙(기존 유지):
+
+1. `handleStartTimeChange`는 startTime을 갱신하고, 기존 endTime이 새 startTime 이하이면 endTime을 `null`로 초기화한다.
+2. `handleEndTimeChange`는 `isValidTimeRange`가 `false`면 무시한다.
+3. `onChange`는 start·end가 모두 설정된 경우에만 호출한다.
+
+---
+
+## 5. 컴포넌트 인터페이스 (Phase 1 갱신)
+
+### 5.1 `TimeRangePicker` (재설계)
+
+위치: `src/features/time-range-select/ui/TimeRangePicker.tsx`
+
+```ts
+interface TimeRangePickerProps {
+  isEnabled: boolean;
+  onEnabledChange: (next: boolean) => void;
+  initialStartTime?: TimeValue; // 기본 { hour: 9, minute: 0 }
+  initialEndTime?: TimeValue; // 기본 { hour: 12, minute: 0 }
+  onRangeChange?: (
+    range: { startTime: TimeValue; endTime: TimeValue } | null,
+  ) => void;
+}
+```
+
+동작 보장:
+
+- 섹션 헤더 `시간 투표 받기` + 우측 토글(`shared/ui/toggle/Toggle`).
+- 토글 ON일 때만 `시작 시간` / `종료 시간` 카드(`HH : mm`) 노출.
+- 카드 탭 → 바텀 시트(`shared/ui/bottom-sheet/BottomSheet`) 내 `TimeWheelPicker` + `확인` 버튼.
+- 바텀 시트 `확인` 확정 후 `isValidTimeRange(start, end)`이 true일 때만 `onRangeChange(range)` 호출, 그 외에는 `onRangeChange(null)`.
+- 토글 OFF로 전환 시 내부 상태는 유지하되 `onRangeChange(null)`을 호출한다.
+
+### 5.2 `TimeWheelPicker` (기존 유지)
+
+```ts
+interface TimeWheelPickerProps {
+  value: TimeValue;
+  onChange: (value: TimeValue) => void;
+  minTime?: TimeValue; // 종료 휠에 start 전달
+  maxTime?: TimeValue; // 시작 휠에 end 전달
+}
+```
+
+### 5.3 `shared/ui/toggle/Toggle` (신규)
+
+```ts
+interface ToggleProps {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  disabled?: boolean;
+  id?: string;
+  ariaLabel?: string;
+}
+```
+
+- `role="switch"`, `aria-checked={checked}`를 렌더한다.
+- 키보드: Space/Enter로 토글. 포커스 링 표시.
+- 시각: Tailwind + CVA — `on`/`off` variant, 44px 최소 터치 영역.
+
+---
+
+## 6. 엔티티 관계 요약
+
+```
+DateSelectPage (UI 상태 소유)
+  ├─ selectedDates: Date[]      ← host-range-selector/useDateSelection
+  ├─ isTimeRangeEnabled: boolean
+  └─ timeRange: { startTime: TimeValue; endTime: TimeValue } | null
+        │
+        ▼ (유효하고 토글 ON일 때만)
+  formatTime × 2  →  TimeRangePayload
+        │
+        ▼
+  useDateSelect.handleNext(formattedDates, timeRangePayload?)
+        │
+        ▼
+  createMeeting(CreateMeetRequest with optional timeRange)
+        │
+        ▼
+  POST /v1/meeting  →  { id }
+```

--- a/specs/feat/131-time-range-picker/plan.md
+++ b/specs/feat/131-time-range-picker/plan.md
@@ -1,0 +1,178 @@
+# Implementation Plan: Time Range Picker (날짜 선택 페이지 통합)
+
+**Branch**: `feat/#131-time-range-picker` | **Date**: 2026-04-20 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/feat/131-time-range-picker/spec.md`
+
+## Summary
+
+모임 생성 2단계(`/date`)에 `시간 투표 받기` 토글과 `시작/종료 시간` 카드 + iOS 스타일 바텀 시트 휠 피커를 통합한다. `src/features/time-range-select/`에 이미 구현된 `TimeRangePicker`·`TimeWheelPicker`·`useTimeRangeSelect`·`timeUtils`를 Figma 최종 UI(토글 스위치, 카드 레이아웃, 09:00/12:00 기본값, 자정 교차 금지)에 맞게 정돈하고, `meet-create-date` 피처의 `useDateSelect` 훅 및 `DateSelectPage`가 토글 상태·시간 범위를 받아 `createMeeting`을 호출하도록 연결한다. `entities/meet`의 `createMeetRequestDto`는 optional `timeRange: { startTime, endTime }` 필드를 허용하도록 확장한다(토글 OFF 시 필드 생략).
+
+## Technical Context
+
+**Language/Version**: TypeScript 5
+**Primary Dependencies**: React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul(바텀 시트 — `@/shared/ui/bottom-sheet/BottomSheet`에서 캡슐화), date-fns ^4.1.0, react-datepicker ^9.1.0(기존), ky(HTTP), zod(검증), Amplitude(analytics)
+**Storage**: N/A — 클라이언트 상태만. 서버 저장은 `POST /v1/meeting` 바디에 직렬화된 `timeRange`로 단발 전송.
+**Testing**: Vitest(단위: `timeUtils`, `useTimeRangeSelect`, DTO 검증), Playwright(선택: `/date` 플로우 E2E). 현재 저장소에 `src/features/time-range-select/lib/timeUtils.test.ts`가 이미 존재.
+**Target Platform**: 모바일 웹 우선(iOS Safari / Android Chrome), 데스크톱 Chrome 보조. 뷰포트 폭 ≥320px.
+**Project Type**: Single Next.js 앱 (`src/` 단일 트리) — FSD 구조.
+**Performance Goals**: 휠 스크롤 60fps, 바텀 시트 open/close < 200ms, `/date` 최초 인터랙션 가능 시점 < 1s(캐시된 상태).
+**Constraints**:
+
+- 토글 OFF 시 요청 바디에 `timeRange` 필드가 절대 포함되지 않아야 함(SC-004, 0%).
+- `endTime > startTime` 엄격 강제(자정 교차 불허) — 100% 클라이언트 차단(SC-003).
+- 시간 옵션은 30분 단위(`minute ∈ {0, 30}`) 고정.
+- 로컬 타임존 기준으로 `"HH:mm"` 문자열 그대로 전송(타임존 변환 없음).
+  **Scale/Scope**: UI 기준 단일 페이지(`/date`) + 개발용 테스트 페이지(`/test/time-picker`) 1곳. 영향 파일 ≈ 8개(entities DTO/api 2, feature model/ui 4, app page 1, amplitude 이벤트 1). 신규 컴포넌트 라인 수 < 400.
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle                       | Status  | Evidence                                                                                                                                                                                                 |
+| ------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| I. FSD 레이어                   | ✅ PASS | `app/date/page.tsx` → `features/meet-create-date/ui/DateSelectPage.tsx` → `features/time-range-select/ui/TimeRangePicker.tsx` → `entities/meet/api/createMeeting.ts` 방향 단방향.                        |
+| II. 프로젝트 구조(`src/`)       | ✅ PASS | 모든 변경이 `src/` 하위에 위치(`apps/`/`packages/` 아님 — 단일 앱 구조).                                                                                                                                 |
+| III. No Barrel Exports          | ✅ PASS | 각 파일 직접 import 유지(`@/features/time-range-select/ui/TimeRangePicker` 등).                                                                                                                          |
+| IV. Unidirectional Dependencies | ✅ PASS | `lib(timeUtils) → model(useTimeRangeSelect) → ui(TimeRangePicker/WheelPicker/WheelColumn)` 순서 유지. `shared/ui/bottom-sheet`·`shared/ui/button`·`shared/ui/checkbox`만 의존. `shared`는 도메인 미참조. |
+| V. Consistent Code Style        | ✅ PASS | `export default function ...` 컴포넌트, `use...` 훅 네이밍, `handle...` 이벤트 핸들러, `is/has/should` boolean 접두사. 신규 DTO 필드도 camelCase.                                                        |
+
+**결과**: 모든 게이트 통과. `Complexity Tracking` 섹션은 비워둔다.
+
+위반 후보 검토:
+
+- **Toggle 스위치**: 현재 `src/shared/ui/`에 Toggle/Switch 컴포넌트가 없다. 도메인 비의존이므로 `shared/ui/toggle/Toggle.tsx`에 신규 추가하는 것이 원칙상 자연스럽다. feature 내부에 숨기면 재사용이 어렵고, shared에 두어도 다른 도메인을 참조하지 않으므로 레이어 규칙 위반이 없다.
+- **Skip 체크박스 → Toggle 이관**: 기존 `TimeRangePicker.tsx`의 `onSkip` + Checkbox UI는 Figma 스펙상 상단 토글로 이동한다. feature의 public API를 `isEnabled` / `onToggle` 중심으로 재설계해도 FSD 레이어와 의존 방향에는 영향 없음(구조 변경이 아닌 동일 레이어 내 시그니처 변경).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/feat/131-time-range-picker/
+├── plan.md              # This file (/speckits:plan output)
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output — decisions & rationale
+├── data-model.md        # Phase 1 output — entities and schema
+├── contracts/
+│   └── create-meeting.md  # POST /v1/meeting 확장 계약
+└── tasks.md             # /speckits:tasks 에서 생성 예정 (이 명령에서는 생성하지 않음)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── app/
+│   ├── date/
+│   │   └── page.tsx                                    # [수정] searchParams → DateSelectPage props 유지
+│   └── test/
+│       └── time-picker/
+│           └── page.tsx                                # [수정] 토글 기반 API로 정렬(User Story 4)
+│
+├── features/
+│   ├── meet-create-date/
+│   │   ├── model/
+│   │   │   └── useDateSelect.ts                        # [수정] timeRange 옵션 수신 → createMeeting 호출 시 조건부 포함, 토글 ON/OFF Amplitude 속성 추가
+│   │   └── ui/
+│   │       └── DateSelectPage.tsx                      # [수정] 달력 아래 TimeRangePicker 배치, 토글 상태/범위 상태 관리, CTA 활성화 규칙 확장
+│   │
+│   └── time-range-select/
+│       ├── lib/
+│       │   ├── timeUtils.ts                            # [유지] formatTime/timeToMinutes/isValidTimeRange/getEndTimeOptions
+│       │   └── timeUtils.test.ts                       # [유지/보강] 기존 단위 테스트
+│       ├── model/
+│       │   ├── types.ts                                # [유지] TimeValue / TimeRange / TimeOption
+│       │   └── useTimeRangeSelect.ts                   # [유지] 내부 상태 훅
+│       └── ui/
+│           ├── TimeRangePicker.tsx                     # [수정] 토글 + 카드 레이아웃 + 09:00/12:00 기본, props 재설계(isEnabled/onEnabledChange/onRangeChange)
+│           ├── TimeWheelPicker.tsx                     # [유지] 휠 피커(이미 min/max 제약 지원)
+│           └── TimeWheelColumn.tsx                     # [유지]
+│
+├── entities/
+│   └── meet/
+│       ├── dto/
+│       │   └── meet.dto.ts                             # [수정] createMeetRequestDto에 optional timeRange 필드 추가(zod)
+│       └── api/
+│           └── createMeeting.ts                        # [유지] DTO parse로 검증(스키마 확장만으로 대응)
+│
+└── shared/
+    └── ui/
+        └── toggle/
+            └── Toggle.tsx                              # [신규] iOS 스타일 토글 스위치(도메인 비의존)
+```
+
+**Structure Decision**: 단일 Next.js 앱 FSD 구조. 본 피처는 **기존 `features/time-range-select` 재배선 + `features/meet-create-date` 통합**으로 구현되며, 신규 도메인 비의존 컴포넌트인 Toggle만 `shared/ui/toggle/`에 추가한다. `entities/meet/dto/meet.dto.ts`의 `createMeetRequestDto` 확장이 서버 계약 변경 지점이며, 나머지 변경은 UI/상태 조립에 국한된다.
+
+## Phase 0 — Outline & Research
+
+Phase 0 결과는 [research.md](./research.md)에 기록한다. 주요 결론:
+
+1. **Toggle 컴포넌트 위치**: `src/shared/ui/toggle/Toggle.tsx` 신규 생성. 근거: 도메인 무관, 향후 `maxParticipantCount` 등 다른 설정 토글 재사용 가능.
+2. **TimeRangePicker API 재설계**: `isEnabled`/`onEnabledChange`/`onRangeChange`/`initialStartTime`/`initialEndTime` 외부 제어 방식. 기존 `onComplete`/`onSkip`은 제거(내부 확정 시점은 바텀 시트 확인 버튼으로 단일화).
+3. **기본값**: `startTime = { hour: 9, minute: 0 }`, `endTime = { hour: 12, minute: 0 }` (spec Clarification 2026-04-20).
+4. **자정 교차 차단**: 종료 휠의 min 제약을 startTime으로 고정해 옵션 단계에서 비활성화(기존 `getEndTimeOptions` / `TimeWheelPicker`의 `minTime` 재사용).
+5. **직렬화**: `formatTime(TimeValue) → "HH:mm"` — 타임존 변환 없음.
+6. **DTO 확장 방식**: `createMeetRequestDto`에 `timeRange: z.object({ startTime, endTime }).optional()` 추가. zod가 `undefined`는 직렬화에서 제외하므로 토글 OFF 시 필드가 자동으로 body에서 누락 — 추가 분기 불필요.
+7. **Amplitude**: 기존 `host_create_meeting_cta_click` 이벤트에 `time_range_enabled: boolean` 속성 추가. 값 지정 시 `start_time`·`end_time`(HH:mm) 속성 동반.
+8. **테스트 페이지(`/test/time-picker`)**: 새 외부 제어 API에 맞춰 토글/범위/결과 출력 로직으로 재배선.
+
+## Phase 1 — Design & Contracts
+
+### Entities & Data Model
+
+자세한 엔티티 정의는 [data-model.md](./data-model.md) 참조. 요약:
+
+- `TimeValue { hour: 0..23, minute: 0 | 30 }` (기존 유지)
+- `TimeRange { startTime: TimeValue; endTime: TimeValue }` (feature 내 런타임 타입, 완료 상태)
+- `TimeRangePayload { startTime: string; endTime: string }` (서버 직렬화 타입, `"HH:mm"`)
+- `CreateMeetRequest` 확장: `{ title, hostName, dates, timeRange?: TimeRangePayload }`
+
+### API Contracts
+
+자세한 계약은 [contracts/create-meeting.md](./contracts/create-meeting.md) 참조. 요약:
+
+- **POST** `/v1/meeting` (ky, baseURL 공용)
+  - 토글 OFF: `{ title, hostName, dates }`
+  - 토글 ON: `{ title, hostName, dates, timeRange: { startTime, endTime } }`
+  - 검증: `createMeetRequestDto.parse(body)` — zod optional `timeRange`가 형식(regex `^([01]\d|2[0-3]):(00|30)$`)과 `startTime < endTime` 불변식을 강제.
+  - 응답: 기존과 동일 `{ id }`.
+
+### FSD Component Wiring
+
+```text
+app/date/page.tsx (Server)
+  └─ features/meet-create-date/ui/DateSelectPage.tsx (Client, 조립 Page)
+       ├─ features/host-range-selector/ui/ReactDatepickerAdapter
+       ├─ features/time-range-select/ui/TimeRangePicker   [수정 대상]
+       │    ├─ shared/ui/toggle/Toggle                    [신규]
+       │    ├─ shared/ui/bottom-sheet/BottomSheet
+       │    ├─ shared/ui/button/Button
+       │    └─ features/time-range-select/ui/TimeWheelPicker
+       ├─ shared/ui/top-bar/TopBar
+       └─ shared/ui/button/Button (모임 만들기 CTA)
+          └─ entities/meet/api/createMeeting  ← features/meet-create-date/model/useDateSelect 에서 호출
+```
+
+`update-agent-context.sh` 실행으로 CLAUDE.md 최상단 Recent Changes는 본 plan 생성 시점에 이미 반영된 상태(`feat/#131-time-range-picker`).
+
+### Architecture Decision Table
+
+| Decision                     | Options Considered                                                                                                      | Chosen                            | Rationale                                                                                                             | FSD Impact                                                                        |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Toggle 컴포넌트 위치         | (a) `shared/ui/toggle/`, (b) `features/time-range-select/ui/`, (c) 인라인                                               | (a) `shared/ui/toggle/Toggle.tsx` | 도메인 비의존이며 재사용성 높음(향후 최대 인원 on/off 등).                                                            | `shared`층에 신규 파일 1개 추가, feature → shared 단방향 의존 준수.               |
+| TimeRangePicker props 재설계 | (a) 기존 `onComplete`/`onSkip` 유지, (b) 외부 제어(`isEnabled`/`onEnabledChange`/`onRangeChange`)                       | (b)                               | Figma는 토글이 항상 보이는 상단 헤더. 외부(부모 `DateSelectPage`)가 토글 상태를 소유해야 CTA 활성화 조건을 계산 가능. | feature 내부에서만 시그니처 변경, 레이어 경계 영향 없음.                          |
+| 기본값(09:00/12:00)          | (a) 09:00/18:00 기존값 유지, (b) 09:00/12:00(Figma)                                                                     | (b)                               | spec Clarification 2026-04-20 확정.                                                                                   | `TimeRangePicker.tsx`의 `DEFAULT_END_TIME` 상수만 변경.                           |
+| 자정 교차 처리               | (a) cross-midnight 허용, (b) `endTime > startTime` 엄격                                                                 | (b)                               | spec Edge Cases, SC-003. 기존 `isValidTimeRange` 구현과 일치.                                                         | 변경 없음(기존 유틸 재사용).                                                      |
+| DTO 확장 위치                | (a) 신규 DTO 분리, (b) 기존 `createMeetRequestDto` 확장                                                                 | (b)                               | API가 동일 엔드포인트·동일 베이스 페이로드. 옵셔널 필드 추가가 가장 단순.                                             | `entities/meet/dto/meet.dto.ts` 1파일 수정.                                       |
+| 토글 OFF 시 body 누락 방식   | (a) 명시적 `if`로 필드 제거, (b) `timeRange: undefined` 전달 후 zod strip                                               | (b)                               | zod `z.object(...).optional()`는 `undefined`를 직렬화에서 자연 제외. 분기 최소화.                                     | `useDateSelect.ts`에서 `isEnabled ? timeRange : undefined`로 단일 라인 처리.      |
+| 휠 피커 min/max 제약         | (a) 피커 내부 동적 계산, (b) 부모가 매번 계산해 props로 주입                                                            | (a)                               | `TimeWheelPicker`가 이미 `minTime`/`maxTime` props로 자체 필터링. 재작성 불필요.                                      | 변경 없음.                                                                        |
+| Amplitude 확장 이벤트        | (a) 신규 이벤트 생성, (b) 기존 `host_create_meeting_cta_click`에 속성 추가                                              | (b)                               | 퍼널 단절 방지. FR-011도 속성 추가로 기술.                                                                            | `features/meet-create-date/model/useDateSelect.ts`의 `trackEvent` 호출 속성 확장. |
+| 테스트 위치                  | (a) `src/features/time-range-select/lib/*.test.ts` 유지 + `useTimeRangeSelect.test.ts` 추가, (b) `tests/` 디렉토리 신설 | (a)                               | Vitest가 공동 배치(co-located) 경로를 이미 수집 중(`timeUtils.test.ts` 선례).                                         | feature 폴더에 `.test.ts` 1~2개 추가.                                             |
+
+### Agent Context Sync
+
+`.specify/scripts/bash/update-agent-context.sh claude` 실행 결과 CLAUDE.md 상단 Recent Changes에 `feat/#131-time-range-picker` 항목이 이미 반영되어 있어 추가 실행 없이 Phase 1을 종료한다.
+
+## Complexity Tracking
+
+> Constitution Check의 모든 게이트를 통과하여 위반 사항이 없다. 본 섹션은 비워둔다.

--- a/specs/feat/131-time-range-picker/research.md
+++ b/specs/feat/131-time-range-picker/research.md
@@ -1,0 +1,162 @@
+# Phase 0 — Research: Time Range Picker (날짜 선택 페이지 통합)
+
+**Feature**: `feat/#131-time-range-picker`
+**Updated**: 2026-04-20 (통합 단계)
+**Prior research**: 최초 `time-range-select` feature 구축(2026-04-07) 결정은 이 문서의 Appendix 참조.
+
+이번 Phase 0은 `/date` 페이지 통합을 위해 새로 해소해야 하는 결정을 기록한다.
+
+---
+
+## R1. Toggle 스위치 컴포넌트 위치
+
+- **Decision**: `src/shared/ui/toggle/Toggle.tsx`에 iOS 스타일 토글 컴포넌트를 신규 생성한다. 최소 props: `checked`, `onChange`, `disabled?`, `id?`, `ariaLabel?`. Tailwind + CVA `on`/`off` variant.
+- **Rationale**:
+  - 도메인 비의존이며 `shared/ui/checkbox/Checkbox.tsx`와 같은 계층이 자연스럽다.
+  - 향후 `maxParticipantCount` 등 다른 설정 토글에서 재사용 가능.
+  - `role="switch"` · `aria-checked` 등 접근성 책임을 shared에 귀속.
+- **Alternatives considered**:
+  - `features/time-range-select/ui/Toggle.tsx` 내장: 발견성·재사용성 낮음.
+  - 인라인 JSX: 접근성·디자인 토큰 책임이 feature로 누수.
+
+---
+
+## R2. `TimeRangePicker` public API 재설계
+
+- **Decision**: 외부 제어(controlled) 방식으로 바꾼다.
+
+  ```ts
+  interface TimeRangePickerProps {
+    isEnabled: boolean;
+    onEnabledChange: (next: boolean) => void;
+    initialStartTime?: TimeValue; // 기본 { hour: 9, minute: 0 }
+    initialEndTime?: TimeValue; // 기본 { hour: 12, minute: 0 }
+    onRangeChange?: (
+      range: { startTime: TimeValue; endTime: TimeValue } | null,
+    ) => void;
+  }
+  ```
+
+  기존 `onComplete`·`onSkip`은 제거한다. 내부 상태 훅(`useTimeRangeSelect`)과 `activeField`·`pendingValue` 로컬 상태는 그대로 사용.
+
+- **Rationale**: 부모(`DateSelectPage`)가 토글 상태·범위를 모두 알아야 CTA 활성화와 요청 바디를 결정 가능. 확정 시점은 바텀 시트 "확인"으로 단일화.
+- **Alternatives considered**:
+  - 기존 체크박스(`onSkip`) 유지: Figma 상단 토글 스펙과 불일치.
+  - `forwardRef` imperative API: controlled prop 대비 이점 없음.
+
+---
+
+## R3. 시간 기본값 (09:00 / 12:00)
+
+- **Decision**: `DEFAULT_START_TIME = { hour: 9, minute: 0 }`, `DEFAULT_END_TIME = { hour: 12, minute: 0 }`.
+- **Rationale**: spec Clarification 2026-04-20에서 확정. 기존 상수 `DEFAULT_END_TIME = 18:00`만 교체.
+- **Alternatives considered**: 마지막 값 복원(localStorage) — 범위 외.
+
+---
+
+## R4. 자정 교차 금지 · `endTime > startTime` 강제
+
+- **Decision**: UI(휠 옵션 disable, `TimeWheelPicker`의 `minTime`/`maxTime` 제약)와 서버 호출 직전 검증(zod `.refine`) 이중 차단.
+- **Rationale**: SC-003(0% 위반) 보장. 기존 `isValidTimeRange`·`getEndTimeOptions` 재사용.
+- **Alternatives considered**: cross-midnight 허용 — Edge Cases에서 명시적으로 불허.
+
+---
+
+## R5. `"HH:mm"` 직렬화 & 타임존 중립
+
+- **Decision**: `formatTime(TimeValue) → "HH:mm"`만 사용, 타임존 변환 없음.
+- **Rationale**: 서버가 로컬 라벨 문자열로 해석하는 것이 합의(FR-009, Assumptions).
+- **Alternatives considered**: ISO 문자열/Date — 서버 스키마와 불일치.
+
+---
+
+## R6. `createMeetRequestDto` 확장 전략
+
+- **Decision**: 단일 스키마 내 `timeRange` 옵셔널 + `startTime < endTime` `refine`.
+
+  ```ts
+  const TIME_PATTERN = /^([01]\d|2[0-3]):(00|30)$/;
+  const timeRangeDto = z
+    .object({
+      startTime: z.string().regex(TIME_PATTERN),
+      endTime: z.string().regex(TIME_PATTERN),
+    })
+    .refine(({ startTime, endTime }) => startTime < endTime, {
+      message: 'endTime은 startTime보다 커야 합니다.',
+    });
+
+  export const createMeetRequestDto = z.object({
+    title: z.string().min(1, '모임 이름은 필수입니다.'),
+    hostName: z.string().min(1, '모임장 이름은 필수입니다.'),
+    dates: z.array(z.string()).min(1, '날짜를 선택해주세요.'),
+    timeRange: timeRangeDto.optional(),
+  });
+  ```
+
+- **Rationale**: `.optional()`은 `undefined`를 직렬화에서 제외 → 토글 OFF 시 `body.timeRange = undefined`만으로 필드가 누락되어 SC-004(0% 포함) 자동 달성. `"HH:mm"` 문자열 사전식 비교가 올바르게 동작(leading zero).
+- **Alternatives considered**: 별도 요청 타입 분리(호출부 분기 비용↑), 서버 전용 검증(SC-003 미달).
+
+---
+
+## R7. `useDateSelect` 훅 시그니처 확장
+
+- **Decision**: `handleNext(formattedDates, timeRangePayload?)` 형태로 시그니처를 확장한다(페이로드는 `{ startTime: string; endTime: string } | undefined`). 훅 내부는 받은 페이로드를 그대로 `createMeeting` 호출에 주입.
+- **Rationale**: 상태 소유권은 UI(`DateSelectPage`)에 두고 훅은 transport 역할만 담당 — `features/time-range-select`와의 역방향 의존 방지.
+- **Alternatives considered**: 훅이 `time-range-select` 내부 훅을 관통해 상태까지 소유 — 같은 레이어(feature ↔ feature) 간 교차 참조 발생.
+
+---
+
+## R8. Amplitude 이벤트 속성 확장
+
+- **Decision**: 기존 `host_create_meeting_cta_click`에 속성 추가.
+
+  ```ts
+  trackEvent('host_create_meeting_cta_click', {
+    total_days: formattedDates.length,
+    time_range_enabled: Boolean(timeRangePayload),
+    start_time: timeRangePayload?.startTime,
+    end_time: timeRangePayload?.endTime,
+  });
+  ```
+
+- **Rationale**: 퍼널 유지 + 옵션 사용률 추적(FR-011).
+- **Alternatives considered**: 신규 이벤트(`host_time_range_set`) — 중복 이벤트로 퍼널 복잡도 증가.
+
+---
+
+## R9. `/test/time-picker` 페이지 정렬
+
+- **Decision**: 새 외부 제어 API(`isEnabled`/`onEnabledChange`/`onRangeChange`)로 재배선. 토글 OFF거나 유효 범위일 때 CTA 활성화.
+- **Rationale**: User Story 4(독립 QA) 요건 충족.
+- **Alternatives considered**: 테스트 페이지 삭제 — 디자인 QA 편의 상실.
+
+---
+
+## R10. 테스트 전략
+
+- **Decision**:
+  - 기존 `src/features/time-range-select/lib/timeUtils.test.ts` 유지·보강(자정 경계, 30분 경계).
+  - 신규 `src/entities/meet/dto/meet.dto.test.ts`로 `createMeetRequestDto` 확장(패턴/순서/옵셔널) 단위 테스트.
+  - 컴포넌트 테스트는 jsdom 미도입 제약으로 본 이슈 범위 외(최초 research Appendix 참고). 통합 검증은 `/test/time-picker`와 `/date` 수동 QA로 대체.
+- **Rationale**: 비즈니스 불변식은 순수 함수·zod 수준에서 100% 강제. UI는 환경 제약 상 수동 QA 유지.
+- **Alternatives considered**: jsdom 도입 → 별도 이슈로 분리.
+
+---
+
+## Outstanding Unknowns
+
+없음. 2026-04-20 Clarification 세션 이후 Technical Context 전 항목이 확정되었다.
+
+---
+
+## Appendix — 2026-04-07 초기 결정 요약(참고용)
+
+| 항목               | 결정                                             |
+| ------------------ | ------------------------------------------------ |
+| 타임피커 UI        | 커스텀 휠(`TimeWheelColumn` + `TimeWheelPicker`) |
+| 시간 값 타입       | `{ hour: number, minute: 0 \| 30 }`              |
+| TDD 대상           | `lib/timeUtils.ts` 순수 함수 (Vitest node env)   |
+| 유효성 처리        | 종료 옵션에서 시작 이하 슬롯 disable             |
+| 테스트 페이지 경로 | `src/app/test/time-picker/page.tsx`              |
+
+본 통합 단계는 위 결정을 승계하고, 상단 R1~R10으로 확장한다.

--- a/specs/feat/131-time-range-picker/spec.md
+++ b/specs/feat/131-time-range-picker/spec.md
@@ -1,0 +1,149 @@
+# Feature Specification: Time Range Picker (날짜 선택 페이지 통합)
+
+**Feature Branch**: `feat/#131-time-range-picker`
+**Created**: 2026-04-06
+**Updated**: 2026-04-20
+**Status**: Draft (Rewritten — UI finalized)
+**GitHub Issue**: #131
+
+## Overview
+
+모임 생성 2단계(`/date`)에서 호스트가 **날짜 범위 선택** 직후 **시간 투표 받기 여부**를 토글로 선택하고, 활성화 시 **투표 가능한 시작/종료 시각**을 30분 단위로 지정할 수 있도록 한다.
+
+Figma에서 확정된 UI는 다음과 같다.
+
+1. 상단: 월 달력(기존 `ReactDatepickerAdapter`)을 통한 날짜 복수 선택
+2. 중단: `시간 투표 받기` 헤더 + 우측 토글 스위치
+3. 하단(토글 ON 시): `시작 시간` / `종료 시간` 두 줄 — 각 줄은 `HH : mm` 카드(테두리 라운드, 가운데 정렬) 형태로 표시되며, 탭하면 바텀 시트의 iOS 스타일 휠 피커가 올라온다.
+4. 바텀 시트: 중앙 선택 행이 강조(라이트 회색 배경)되고, 상하 항목은 색상이 점진적으로 흐려지는 페이드 효과를 갖는다. 확인 버튼으로 값을 확정한다.
+5. 최하단: `모임 만들기` CTA. 필수 조건(날짜 1개 이상, 토글 ON 시 유효한 시간 범위)을 만족할 때만 활성화된다.
+
+`src/features/time-range-select/`에 휠 피커·범위 훅·유틸이 이미 구현되어 있으므로, 본 피처의 핵심은 **기존 컴포넌트를 Figma 최종 UI에 맞게 정돈하고 `/date` 페이지에 통합하여, 확정된 요청 바디 스키마로 모임을 생성하는 것**이다.
+
+## Clarifications
+
+### Session 2026-04-20
+
+- Q: 시간 범위 미설정(토글 OFF) 시 서버로 전송되는 `timeRange` 값은? → A: 요청 바디에서 `timeRange` 필드를 생략한다(선택 필드).
+- Q: 초기 시간 기본값은? → A: Figma 기준 `시작 09:00 / 종료 12:00`.
+- Q: 자정 교차(예: 22:00 ~ 02:00) 허용 여부? → A: 불허. `endTime`은 `startTime`보다 엄격히 커야 한다.
+- Q: `maxParticipantCount`는 이 피처에서 다루는가? → A: 다루지 않는다. 서버 스키마가 확장됨은 인지하되, UI 입력은 별도 티켓에서 처리한다.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 — 날짜만 정하고 모임 생성 (Priority: P1)
+
+호스트가 날짜 범위만 선택하고 시간 투표는 받지 않기로 결정한다.
+
+**Why this priority**: 기존 플로우와의 하위 호환이며, 가장 빠른 모임 생성 경로이다.
+
+**Independent Test**: `/date?hostName=...&meetingName=...` 접속 → 날짜 1개 이상 선택 → 시간 토글 OFF 유지 → `모임 만들기` 탭 → 요청 바디에 `timeRange`가 포함되지 않은 채 모임이 생성된다.
+
+**Acceptance Scenarios**:
+
+1. **Given** `/date`에 진입하여 시간 토글이 OFF 상태일 때, **When** 날짜를 1개 이상 선택하면, **Then** `모임 만들기` 버튼이 활성화된다.
+2. **Given** 토글이 OFF인 상태에서 `모임 만들기`를 누르면, **When** `createMeeting` API가 호출될 때, **Then** 요청 바디는 `{ title, hostName, dates }` 형태로 `timeRange` 필드를 포함하지 않는다.
+3. **Given** 토글 영역에 시작/종료 시간 입력이 숨겨진 상태에서, **When** 토글을 탭하여 ON으로 바꾸면, **Then** 시작/종료 시간 카드가 표시되고 기본값 `09:00` / `12:00`이 채워진다.
+
+---
+
+### User Story 2 — 시간 투표 받기 설정 (Priority: P1)
+
+호스트가 날짜 범위에 더해 하루 중 투표 가능한 시간 범위를 30분 단위로 지정한다.
+
+**Why this priority**: 본 이슈의 핵심 가치. 시간대 범위를 지정하지 못하면 참여자 투표 화면에서 슬롯이 하루 전체가 되어 선택 피로도가 높아진다.
+
+**Independent Test**: 토글 ON → `시작 시간` 카드를 탭하면 바텀 시트 휠 피커가 열린다. 원하는 시각을 스크롤로 맞추고 확인을 탭하면 해당 값이 카드에 반영된다. 종료 시간도 동일하게 지정한다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 토글이 ON이고 `시작 시간` 카드가 보이는 상태에서, **When** 카드를 탭하면, **Then** 바텀 시트가 열리고 제목 `시작 시간`과 함께 시/분 휠 피커가 표시된다.
+2. **Given** 바텀 시트가 열린 상태에서, **When** 시 컬럼·분 컬럼을 각각 스크롤하면, **Then** 중앙 강조 행의 값이 실시간으로 바뀐다.
+3. **Given** 휠 피커에서 `10 : 30`으로 맞춘 상태에서, **When** 확인 버튼을 탭하면, **Then** 바텀 시트가 닫히고 `시작 시간` 카드 표시가 `10 : 30`으로 갱신된다.
+4. **Given** 유효한 `시작 시간(09:00)`과 `종료 시간(12:00)`이 설정된 상태에서, **When** `모임 만들기`를 탭하면, **Then** 요청 바디는 `{ title, hostName, dates, timeRange: { startTime: "09:00", endTime: "12:00" } }` 형태로 전송된다.
+
+---
+
+### User Story 3 — 잘못된 범위 방지 (Priority: P1)
+
+종료 시각이 시작 시각보다 이르거나 같은 경우가 원천적으로 발생하지 않아야 한다.
+
+**Why this priority**: 유효하지 않은 시간 범위는 투표 화면 렌더링 오류로 이어진다.
+
+**Independent Test**: 시작 시간을 변경했을 때 종료 시간 휠 피커의 선택 가능 범위가 조정되는지, 그리고 범위가 깨지면 CTA가 비활성화되는지 확인한다.
+
+**Acceptance Scenarios**:
+
+1. **Given** `시작 시간 = 10:00`인 상태에서, **When** `종료 시간` 휠 피커를 열면, **Then** 10:00 이하의 모든 옵션은 휠에서 노출되지 않거나 선택 불가로 처리된다.
+2. **Given** 시작이 종료보다 늦어지는 상태(예: 종료가 이미 11:00인데 시작을 12:00으로 변경)에서, **When** 시작 시간을 확정하면, **Then** 종료 시간은 자동으로 `시작 시간 + 30분`으로 보정되거나 재선택을 요구한다.
+3. **Given** 종료 시간이 유효하지 않은 상태에서, **When** `모임 만들기` 버튼을 보면, **Then** 버튼은 비활성화되어 있다.
+
+---
+
+### User Story 4 — 테스트 페이지에서 독립 검증 (Priority: P3)
+
+개발자·디자이너가 `/test/time-picker`에서 `TimeRangePicker` 컴포넌트만 독립적으로 검증한다.
+
+**Why this priority**: QA와 디자인 QA 사이클을 빠르게 돌리기 위한 개발 편의 경로이다.
+
+**Independent Test**: `/test/time-picker`에 접속하여 휠 피커·확인 버튼 동작, 토글 UX를 페이지 통합 전 수준에서 단독 점검한다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 테스트 페이지에 접속한 상태에서, **When** `TimeRangePicker`가 렌더링되면, **Then** 섹션 헤더, 시작/종료 시간 카드, 바텀 시트 휠 피커가 Figma 스펙과 동일하게 표시된다.
+2. **Given** 테스트 페이지에서 범위를 확정하면, **When** `onComplete` 콜백이 호출될 때, **Then** 화면 하단에 `HH:mm ~ HH:mm` 형태의 결과가 출력된다.
+
+---
+
+### Edge Cases
+
+- **자정 교차**: `22:00 ~ 02:00` 같은 범위는 허용하지 않는다. 종료 시각은 같은 날짜 내에서 시작 시각보다 엄격히 커야 한다.
+- **동일 시각**: `10:00 ~ 10:00`은 유효하지 않다.
+- **토글 OFF → ON 전환**: 이전에 선택한 값이 있으면 유지하고, 없으면 `09:00 / 12:00`을 기본값으로 사용한다.
+- **토글 ON → OFF 전환**: 이전 값을 상태에 유지하되, 요청 바디에는 포함하지 않는다.
+- **작은 화면(≤320px)**: 바텀 시트 휠 컬럼이 레이아웃을 벗어나지 않아야 한다.
+- **로컬 타임존**: 표시는 항상 로컬 기준 `00:00~23:30`이며, 전송 값도 그대로 `"HH:mm"` 문자열이다(타임존 변환 없음).
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: `/date` 페이지는 달력 아래에 `시간 투표 받기` 섹션 헤더와 토글 스위치를 표시해야 한다.
+- **FR-002**: 토글이 ON일 때만 `시작 시간`·`종료 시간` 카드가 표시되어야 하며, 토글 OFF로 복귀 시 카드는 숨겨져야 한다.
+- **FR-003**: 각 시간 카드를 탭하면 바텀 시트에서 시(0~23)·분(00, 30) 휠 컬럼을 가진 피커가 열려야 한다.
+- **FR-004**: 시스템은 선택 가능한 시간 옵션을 30분 단위로 제공해야 한다.
+- **FR-005**: 시스템은 종료 시각이 시작 시각과 같거나 이른 값으로 확정되는 것을 방지해야 한다(피커 내 옵션 필터링 또는 자동 보정).
+- **FR-006**: 시간 범위 초기값은 `시작 09:00 / 종료 12:00`으로 한다.
+- **FR-007**: `TimeRangePicker` 컴포넌트는 props로 초기값과 완료·토글 콜백을 주입받아 `/date` 페이지와 `/test/time-picker` 페이지에서 동일하게 재사용되어야 한다.
+- **FR-008**: `모임 만들기` 버튼은 다음 조건을 모두 만족할 때만 활성화되어야 한다. (1) 날짜가 1개 이상 선택됨. (2) 시간 토글이 OFF이거나, 토글이 ON일 때 유효한 `startTime < endTime` 범위가 지정됨.
+- **FR-009**: `createMeeting` 요청 바디는 토글 상태에 따라 다음 두 형태 중 하나여야 한다.
+  - 토글 OFF: `{ title, hostName, dates }`
+  - 토글 ON: `{ title, hostName, dates, timeRange: { startTime: "HH:mm", endTime: "HH:mm" } }`
+- **FR-010**: 서버 요청용 DTO(`createMeetRequestDto`)는 optional `timeRange` 필드를 허용하도록 확장되어야 한다.
+- **FR-011**: 시간 범위가 지정된 상태에서 Amplitude 이벤트(`host_create_meeting_cta_click` 등)에 시간 범위 선택 여부가 추적 속성으로 포함되어야 한다.
+- **FR-012**: 모바일 터치(스크롤·탭)와 데스크톱 마우스/휠 모두에서 휠 피커가 동작해야 한다.
+
+### Key Entities
+
+- **TimeValue**: `{ hour: 0..23, minute: 0 | 30 }` — 로컬 기준 시각. 이미 `src/features/time-range-select/model/types.ts`에 정의됨.
+- **TimeRange (요청)**: `{ startTime: "HH:mm", endTime: "HH:mm" }` — API 요청 바디에 포함되는 직렬화 형태. `formatTime(TimeValue)`를 통해 생성.
+- **CreateMeetRequest (확장)**: 기존 `{ title, hostName, dates }`에 `maxParticipantCount?: number`, `timeRange?: TimeRange` 두 옵셔널 필드가 추가된 서버 스키마. 본 피처는 그중 `timeRange`만 사용한다.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: 호스트가 `/date` 진입 후 날짜·시간 모두 확정하고 `모임 만들기`까지 소요되는 시간이 60초 이내이다.
+- **SC-002**: iOS Safari / Android Chrome / 데스크톱 Chrome 3개 환경에서 토글 ON·OFF 전환, 휠 피커 스크롤·확정, CTA 활성화 규칙이 동일하게 동작한다.
+- **SC-003**: 유효하지 않은 시간 범위(`endTime ≤ startTime`)로 서버 요청이 발생하는 비율이 0%이다(클라이언트에서 100% 차단).
+- **SC-004**: 토글 OFF로 생성된 모임의 요청 바디에 `timeRange` 필드가 포함된 비율이 0%이다.
+- **SC-005**: 토글 ON으로 생성된 모임의 요청 바디가 `{ startTime: "HH:mm", endTime: "HH:mm" }` 포맷 검증을 100% 통과한다.
+
+## Assumptions
+
+- 시간은 로컬 타임존 기준이며, 타임존 변환은 본 피처 범위 밖이다.
+- 날짜 선택(`ReactDatepickerAdapter`) 및 드래그 경로 선택(#127 관련)은 이미 구현되어 있으며, 본 피처는 그 뒤의 영역만 추가·변경한다.
+- `maxParticipantCount` UI 입력은 별도 티켓에서 처리하며, 본 피처에서는 DTO 스키마 확장만 고려한다(값 미포함 전송).
+- `src/features/time-range-select/`의 `TimeRangePicker`, `TimeWheelPicker`, `useTimeRangeSelect`, `timeUtils`는 대부분 재사용 가능하며, Figma 시각 스펙에 맞춘 스타일 정돈과 토글·카드 레이아웃 변경 정도가 필요하다.
+- 바텀 시트는 공용 `@/shared/ui/bottom-sheet/BottomSheet`를 계속 사용한다.
+- 디자인 토큰(Pretendard GOV 폰트, `text/primary`, `line/nonclickable` 등)은 이미 프로젝트에 정의되어 있거나, 없을 경우 가장 유사한 기존 토큰을 사용한다.

--- a/specs/feat/131-time-range-picker/tasks.md
+++ b/specs/feat/131-time-range-picker/tasks.md
@@ -1,0 +1,226 @@
+---
+description: 'Task list for feat/#131-time-range-picker — 날짜 선택 페이지에 시간 투표 토글/휠 피커 통합'
+---
+
+# Tasks: Time Range Picker (날짜 선택 페이지 통합)
+
+**Input**: Design documents from `/specs/feat/131-time-range-picker/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/create-meeting.md
+
+**Tests**: 본 피처는 Vitest 단위 테스트(순수 함수·DTO)만 포함한다. 컴포넌트 테스트는 jsdom 미도입으로 범위 외(research R10). UI 검증은 `/test/time-picker`와 `/date` 수동 QA로 수행.
+
+**Organization**: 4개 사용자 스토리별 독립 구현·테스트가 가능하도록 구성.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: 서로 다른 파일·의존 없음 → 병렬 실행 가능
+- **[Story]**: US1~US4는 spec.md 사용자 스토리 매핑
+- 파일 경로는 저장소 루트 기준
+
+## Path Conventions
+
+**본 저장소는 단일 Next.js 앱(`src/` 단일 트리) FSD 구조**이며 monorepo 아님(plan.md §Project Structure). 따라서 경로는 `apps/{app}/src/` 대신 `src/` 접두어를 사용한다.
+
+- `src/app/` → Next.js App Router 페이지
+- `src/features/{feature}/` → FSD feature (ui/model/lib)
+- `src/entities/{entity}/` → 도메인 엔티티 (dto/api)
+- `src/shared/ui/` → 앱 공용 UI
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: 본 피처는 기존 프로젝트(Next.js 16 / Vitest 구성 완료) 위에 얹으므로 신규 setup은 최소한이다.
+
+- [x] T001 브랜치 `feat/#131-time-range-picker` 체크아웃 확인 및 `npm install` 실행으로 `vaul`·`date-fns`·`zod` 포함 의존성 동기화
+- [x] T002 [P] `npm run lint`·`npm test` 최초 실행으로 현재 트리 baseline이 green인지 확인(후속 회귀 감지용)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: 모든 사용자 스토리가 공유하는 재사용 컴포넌트·스키마·기본값. 이 단계가 끝나기 전에는 어떤 US도 착수할 수 없다.
+
+**⚠️ CRITICAL**: Foundational 완료 전까지 US1~US4는 시작 금지.
+
+- [x] T003 [P] iOS 스타일 Toggle 컴포넌트를 [src/shared/ui/toggle/Toggle.tsx](src/shared/ui/toggle/Toggle.tsx) 신규 생성 — props `{ checked, onChange, disabled?, id?, ariaLabel? }`, `role="switch"` · `aria-checked`, Space/Enter 키보드 지원, Tailwind + CVA `on`/`off` variant, 44px 최소 터치 영역 (data-model §5.3, research R1)
+- [x] T004 [P] [src/entities/meet/dto/meet.dto.ts](src/entities/meet/dto/meet.dto.ts)에 `TIME_PATTERN` 정규식 상수(`^([01]\d|2[0-3]):(00|30)$`) + `timeRangeDto`(zod object + `refine: startTime < endTime`) + `createMeetRequestDto.timeRange.optional()` 필드를 추가하고 `TimeRangePayload` 타입 export (data-model §2~3, research R6, contracts §Validation Schema)
+- [x] T005 [P] [src/features/time-range-select/ui/TimeRangePicker.tsx](src/features/time-range-select/ui/TimeRangePicker.tsx)의 `DEFAULT_START_TIME`·`DEFAULT_END_TIME` 상수를 `{ hour: 9, minute: 0 }` / `{ hour: 12, minute: 0 }`로 갱신 (spec Clarification 2026-04-20, research R3)
+- [x] T006 [src/features/time-range-select/ui/TimeRangePicker.tsx](src/features/time-range-select/ui/TimeRangePicker.tsx) public API를 controlled 방식으로 재설계: props `{ isEnabled, onEnabledChange, initialStartTime?, initialEndTime?, onRangeChange? }`로 교체, 기존 `onComplete`·`onSkip` 제거, 섹션 헤더(`시간 투표 받기`) + 우측 Toggle + 토글 ON일 때만 `시작 시간`/`종료 시간` 카드 노출 골격까지 구현 (data-model §5.1, research R2, FR-001~FR-003)
+- [x] T007 T006 완료 후, `TimeRangePicker` 내부에서 `isValidTimeRange(start, end)`가 true일 때만 `onRangeChange({ startTime, endTime })`, 그 외(토글 OFF 포함 및 부분 선택)는 `onRangeChange(null)`를 호출하도록 상태-콜백 동기화 로직 연결 (data-model §5.1 동작 보장)
+
+**Checkpoint**: Toggle 컴포넌트·DTO 확장·TimeRangePicker 신규 API가 준비되어 US1~US4 병렬 착수 가능.
+
+---
+
+## Phase 3: User Story 1 — 날짜만 정하고 모임 생성 (Priority: P1) 🎯 MVP
+
+**Goal**: 호스트가 날짜 범위만 선택하고 시간 투표는 OFF로 둔 채 `모임 만들기`를 눌렀을 때, 요청 바디에 `timeRange` 필드가 **포함되지 않은** 채 모임이 생성된다.
+
+**Independent Test**: `/date?hostName=Alice&meetingName=Test` 접속 → 달력에서 날짜 1개 이상 선택 → 시간 토글 OFF 유지 → DevTools Network에서 `POST /v1/meeting` 요청 바디에 `timeRange` 키가 없음을 확인 → 응답 `{ id }` 수신 및 다음 페이지 네비게이션.
+
+### Implementation for User Story 1
+
+- [x] T008 [US1] [src/features/meet-create-date/model/useDateSelect.ts](src/features/meet-create-date/model/useDateSelect.ts)의 `handleNext` 시그니처를 `handleNext(formattedDates: string[], timeRangePayload?: TimeRangePayload)`로 확장하고, 내부 `createMeeting` 호출 시 `timeRange: timeRangePayload`를 그대로 전달(undefined면 zod `.optional()`이 body에서 자동 누락) (research R7, contracts §Client Call Pattern)
+- [x] T009 [US1] [src/features/meet-create-date/ui/DateSelectPage.tsx](src/features/meet-create-date/ui/DateSelectPage.tsx)에 `isTimeRangeEnabled: boolean`(초기 false)와 `timeRange: { startTime: TimeValue; endTime: TimeValue } | null`(초기 null) 상태 추가, 달력 아래에 `<TimeRangePicker isEnabled={isTimeRangeEnabled} onEnabledChange={setIsTimeRangeEnabled} onRangeChange={setTimeRange} />` 배치 (FR-001~FR-002, plan §FSD Component Wiring)
+- [x] T010 [US1] T009에 이어 `DateSelectPage`의 CTA 활성화 규칙을 확장: `selectedDates.length >= 1 && (!isTimeRangeEnabled || timeRange !== null)` (FR-008)
+- [x] T011 [US1] `DateSelectPage`의 CTA 핸들러에서 `const payload = isTimeRangeEnabled && timeRange ? { startTime: formatTime(timeRange.startTime), endTime: formatTime(timeRange.endTime) } : undefined;`로 직렬화 후 `useDateSelect`의 `handleNext(formattedDates, payload)`로 전달 (contracts §Client Call Pattern, data-model §2 변환 규칙, SC-004)
+
+**Checkpoint**: US1이 독립 동작 — 토글 OFF 경로의 모임 생성이 기존 플로우와 동일하게 완결.
+
+---
+
+## Phase 4: User Story 2 — 시간 투표 받기 설정 (Priority: P1)
+
+**Goal**: 호스트가 토글 ON 후 시작 시간/종료 시간 카드를 탭하여 바텀 시트 휠 피커로 30분 단위 범위를 지정하고, `{ startTime: "HH:mm", endTime: "HH:mm" }`가 요청 바디 `timeRange`에 포함된 채 모임이 생성된다.
+
+**Independent Test**: `/date`에서 토글 ON → `시작 시간` 카드 탭 → 바텀 시트 휠 피커에서 10:30 선택 → 확인 → 카드 표시가 `10 : 30`으로 갱신 → `종료 시간`도 12:00으로 지정 → `모임 만들기` → 요청 바디 `timeRange: { startTime: "10:30", endTime: "12:00" }` 전송.
+
+### Implementation for User Story 2
+
+- [x] T012 [US2] [src/features/time-range-select/ui/TimeRangePicker.tsx](src/features/time-range-select/ui/TimeRangePicker.tsx) 내부에 `activeField: 'start' | 'end' | null` 로컬 상태와 `시작 시간`/`종료 시간` 카드(`HH : mm` 라운드 카드, 가운데 정렬) UI를 Figma 스펙대로 구현, 카드 탭 시 `activeField`를 세팅하여 바텀 시트를 연다 (FR-003, spec Overview §3)
+- [x] T013 [US2] `TimeRangePicker`가 `@/shared/ui/bottom-sheet/BottomSheet`을 사용해 바텀 시트를 열고, 내부에 `TimeWheelPicker`(기존 컴포넌트) + `확인` 버튼을 렌더 — `pendingValue: TimeValue` 로컬 상태에 휠 변경을 반영, `확인` 탭 시 `useTimeRangeSelect`의 `handleStartTimeChange`/`handleEndTimeChange`로 확정 후 바텀 시트 닫기 (FR-003, FR-004, data-model §5.1)
+- [x] T014 [US2] 바텀 시트 내 `TimeWheelPicker`에 `minTime`/`maxTime` 제약 전달 — `activeField === 'end'`일 때 `minTime = startTime`, `activeField === 'start'`일 때 `maxTime = endTime`(이미 설정된 경우) (data-model §5.2, FR-005 전단 차단)
+- [x] T015 [US2] [src/features/meet-create-date/model/useDateSelect.ts](src/features/meet-create-date/model/useDateSelect.ts)의 `host_create_meeting_cta_click` Amplitude 이벤트에 속성 `{ total_days, time_range_enabled: Boolean(timeRangePayload), start_time: timeRangePayload?.startTime, end_time: timeRangePayload?.endTime }` 추가 (FR-011, research R8)
+- [x] T016 [US2] [src/entities/meet/api/createMeeting.ts](src/entities/meet/api/createMeeting.ts) 동작 재검증(코드 변경 없음) — `createMeetRequestDto.parse`가 `timeRange` 포함/미포함 두 경우 모두 통과하는지 수동 확인, 네트워크 바디에 `timeRange: { startTime: "HH:mm", endTime: "HH:mm" }`가 정확히 직렬화되는지 확인 (contracts §Request Body)
+
+**Checkpoint**: US1 + US2가 독립 동작 — 토글 ON으로 시간 범위 설정 후 모임 생성까지 end-to-end 성공(SC-005).
+
+---
+
+## Phase 5: User Story 3 — 잘못된 범위 방지 (Priority: P1)
+
+**Goal**: 종료 시각이 시작 시각 이하로 설정되는 경우를 UI 레벨에서 100% 차단하며, 범위가 깨지면 CTA가 비활성화된다(SC-003: 0%).
+
+**Independent Test**: 시작 10:00 → 종료 휠을 열면 10:00 이하 옵션이 선택 불가. 시작을 12:00으로 변경하면 기존 종료 11:00은 자동 무효화되어 `timeRange === null`, CTA 비활성화.
+
+### Implementation for User Story 3
+
+- [x] T017 [US3] [src/features/time-range-select/model/useTimeRangeSelect.ts](src/features/time-range-select/model/useTimeRangeSelect.ts) 내 `handleStartTimeChange`가 기존 `endTime <= newStartTime`인 경우 `endTime`을 `null`로 초기화하는 동작을 유지/검증하고, `handleEndTimeChange`는 `isValidTimeRange === false`면 무시하도록 보장 (data-model §4 동작 규칙)
+- [x] T018 [US3] [src/features/time-range-select/lib/timeUtils.ts](src/features/time-range-select/lib/timeUtils.ts)의 `getEndTimeOptions(startTime, allSlots)`가 `timeToMinutes(slot) <= timeToMinutes(startTime)`인 모든 옵션에 `isDisabled: true`를 부여하는지 검증·보강 (FR-005 UI 필터링)
+- [x] T019 [US3] [src/features/time-range-select/ui/TimeRangePicker.tsx](src/features/time-range-select/ui/TimeRangePicker.tsx)에서 종료 휠 바텀 시트를 열 때 `TimeWheelPicker`의 `minTime={startTime}`을 항상 전달하여 시작 이하 옵션이 휠 자체에서 노출되지 않도록 확정(US2의 T014 보강 수준의 회귀 가드) (FR-005, spec US3 Acceptance 1)
+- [x] T020 [US3] `TimeRangePicker`에서 `handleStartTimeChange`로 인해 endTime이 null이 될 때 `onRangeChange(null)`가 즉시 호출되도록 연결(T007 정책의 재확인) — 결과적으로 부모 `DateSelectPage`의 `timeRange === null` → CTA 비활성(T010 규칙 재사용) (FR-008, spec US3 Acceptance 2~3)
+
+**Checkpoint**: US1+US2+US3 독립 동작 — 잘못된 범위로 서버 요청이 발생할 수 없음(SC-003 0%).
+
+---
+
+## Phase 6: User Story 4 — 테스트 페이지에서 독립 검증 (Priority: P3)
+
+**Goal**: 개발자·디자이너가 `/test/time-picker`에서 `TimeRangePicker`만 독립 QA 가능.
+
+**Independent Test**: `/test/time-picker` 접속 → 섹션 헤더·토글·카드·바텀 시트가 Figma와 일치 → 범위 확정 시 하단에 `HH:mm ~ HH:mm` 결과 출력.
+
+### Implementation for User Story 4
+
+- [x] T021 [US4] [src/app/test/time-picker/page.tsx](src/app/test/time-picker/page.tsx)를 새 controlled API로 재배선 — `useState`로 `isEnabled`·`range`를 보유하고 `<TimeRangePicker isEnabled={...} onEnabledChange={...} onRangeChange={setRange} />` 렌더, 화면 하단에 `range`가 있으면 `${formatTime(range.startTime)} ~ ${formatTime(range.endTime)}`, 없으면 `'범위 미설정'` 표시 (research R9, spec US4 Acceptance)
+
+**Checkpoint**: 4개 스토리 모두 독립적으로 동작.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: 스토리 전반에 걸친 테스트 커버리지·품질·QA 마감.
+
+- [x] T022 [P] [src/entities/meet/dto/meet.dto.test.ts](src/entities/meet/dto/meet.dto.test.ts) 신규 생성 — contracts §Test Plan의 6개 케이스(optional 누락/정상/regex 실패/refine 실패/동일 시각/24:00 방어) Vitest로 작성 (research R10)
+- [x] T023 [P] [src/features/time-range-select/lib/timeUtils.test.ts](src/features/time-range-select/lib/timeUtils.test.ts) 보강 — 자정 경계(`23:30`), 30분 경계(`09:00`/`09:30`), `getEndTimeOptions` disable 규칙 케이스 추가 (research R10)
+- [x] T024 `npm test && npm run lint` 전체 실행 및 green 확인(CLAUDE.md §Commands)
+- [ ] T025 수동 QA — iOS Safari / Android Chrome / 데스크톱 Chrome 3개 환경에서 (a) 토글 OFF → 모임 생성, (b) 토글 ON → 09:00/12:00 기본값 → 모임 생성, (c) 시작 12:00로 이동 시 종료 자동 무효화, (d) ≤320px 뷰포트 레이아웃, (e) 바텀 시트 open/close < 200ms 체감 확인 (SC-001, SC-002, spec Edge Cases)
+- [ ] T026 [P] DevTools Network 탭에서 토글 OFF 모임 생성 시 요청 바디에 `timeRange` 키가 없음을 캡처해 PR에 첨부(SC-004 증빙)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: 의존 없음 — 즉시 시작
+- **Foundational (Phase 2)**: Setup 완료 후 — 모든 US 차단
+  - T003, T004, T005는 서로 다른 파일 → 병렬
+  - T006은 T005(기본값 상수 교체)와 같은 파일이므로 순차
+  - T007은 T006의 API 골격 위에 쌓임
+- **US1 (Phase 3)**: Foundational 완료 후 — 단독 완결 가능(MVP)
+- **US2 (Phase 4)**: Foundational 완료 후 — US1과 병렬 가능(파일 겹침 시 1인 작업은 순차)
+- **US3 (Phase 5)**: Foundational 완료 후 — US2와 로직이 일부 겹치므로 US2 직후 통합 권장
+- **US4 (Phase 6)**: Foundational 완료 후 — US1~US3과 완전 독립(서로 다른 파일)
+- **Polish (Phase 7)**: US1~US3 완료 후
+
+### User Story Dependencies
+
+- **US1 (P1)**: Foundational 이후. DateSelectPage·useDateSelect에 timeRange 배선 추가.
+- **US2 (P1)**: Foundational 이후. TimeRangePicker·TimeWheelPicker·BottomSheet 상호작용·Amplitude 속성.
+- **US3 (P1)**: Foundational 이후. useTimeRangeSelect·timeUtils 로직·TimeWheelPicker `minTime` 제약.
+- **US4 (P3)**: Foundational(T006~T007) 이후. `/test/time-picker` 단독.
+
+### Within Each User Story
+
+- US1: T008(훅 시그니처) → T009(페이지 통합) → T010(CTA 규칙) → T011(직렬화 호출) 순차
+- US2: T012(카드 UI) → T013(바텀 시트/확인) → T014(min/max) → T015(Amplitude) → T016(검증)
+- US3: T017(훅 동작) / T018(유틸) 병렬 → T019(UI min 주입) → T020(콜백 연결)
+- US4: T021 단독
+
+### Parallel Opportunities
+
+- **Phase 2 foundational**: `T003 // T004 // T005` 병렬(서로 다른 파일)
+- **Phase 3 US1 ↔ Phase 6 US4**: 서로 완전 독립 → 여러 개발자 있으면 병렬 가능
+- **Phase 7 polish**: `T022 // T023 // T026` 병렬(각기 다른 파일/산출물)
+
+---
+
+## Parallel Example: Foundational (Phase 2)
+
+```bash
+# 서로 다른 파일 → 동시에 착수 가능:
+Task: "Toggle 컴포넌트 생성 in src/shared/ui/toggle/Toggle.tsx"
+Task: "meet.dto.ts에 timeRangeDto + createMeetRequestDto.timeRange.optional() 추가"
+Task: "TimeRangePicker DEFAULT_START_TIME/DEFAULT_END_TIME 09:00/12:00로 교체"
+```
+
+## Parallel Example: Polish (Phase 7)
+
+```bash
+Task: "meet.dto.test.ts 신규 생성 (6 케이스)"
+Task: "timeUtils.test.ts 보강 (자정/30분 경계)"
+Task: "SC-004 증빙 스크린샷 캡처"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Phase 1: Setup(T001~T002)
+2. Phase 2: Foundational(T003~T007) — Toggle + DTO + TimeRangePicker 신규 API
+3. Phase 3: US1(T008~T011) — 토글 OFF 기본 경로 완결
+4. **STOP & VALIDATE**: `/date`에서 시간 토글 OFF 유지 상태로 모임 생성, 요청 바디에 `timeRange` 키 없음 검증
+5. 릴리스 가능한 증분(하위 호환 달성)
+
+### Incremental Delivery
+
+1. Setup + Foundational → 공통 기반 준비
+2. US1 → 기존 플로우 하위 호환(MVP) → 데모/배포
+3. US2 → 시간 투표 UI 전체 → 데모/배포
+4. US3 → 엣지 방어 → 데모/배포
+5. US4 → 디자인 QA 경로 마감
+6. 각 스토리는 이전 스토리를 깨지 않고 가치 추가
+
+### Parallel Team Strategy
+
+- 개발자 A: US1 (DateSelectPage + useDateSelect)
+- 개발자 B: US2 (TimeRangePicker 바텀 시트 · Amplitude)
+- 개발자 C: US3 (useTimeRangeSelect/timeUtils 회귀 가드) + US4 (`/test/time-picker`)
+
+단일 개발자 시에는 US2 → US3를 동일 PR 내 순차 처리 권장(파일 겹침).
+
+---
+
+## Notes
+
+- [P] = 서로 다른 파일·의존 없음
+- [Story] = spec.md 사용자 스토리 매핑
+- 각 US는 독립 완결·독립 테스트 가능해야 함
+- 커밋은 태스크 단위 또는 논리적 그룹 단위
+- 체크포인트에서 스토리 독립 검증 후 다음 단계로 진행
+- 본 저장소는 `apps/{app}/src/` monorepo 접두어를 사용하지 않으므로 경로에 `src/`를 그대로 사용

--- a/src/app/test/time-picker/page.tsx
+++ b/src/app/test/time-picker/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState } from 'react';
+
+import { formatTime } from '@/features/time-range-select/lib/timeUtils';
+import type { TimeValue } from '@/features/time-range-select/model/types';
+import TimeRangePicker from '@/features/time-range-select/ui/TimeRangePicker';
+import Button from '@/shared/ui/button/Button';
+
+export default function TimePickerTestPage() {
+  const [isEnabled, setIsEnabled] = useState(false);
+  const [range, setRange] = useState<{
+    startTime: TimeValue;
+    endTime: TimeValue;
+  } | null>(null);
+
+  const isReady = !isEnabled || range !== null;
+
+  return (
+    <main className='flex min-h-screen flex-col items-center bg-white'>
+      <div className='w-full max-w-sm'>
+        <TimeRangePicker
+          isEnabled={isEnabled}
+          onEnabledChange={setIsEnabled}
+          onRangeChange={setRange}
+        />
+
+        <p className='px-5 pb-2 text-center text-sm text-gray-400'>
+          {range
+            ? `${formatTime(range.startTime)} ~ ${formatTime(range.endTime)}`
+            : '범위 미설정'}
+        </p>
+
+        <div className='px-5 pb-6'>
+          <Button fullWidth disabled={!isReady}>
+            모임 만들기
+          </Button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/entities/meet/dto/meet.dto.test.ts
+++ b/src/entities/meet/dto/meet.dto.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMeetRequestDto } from './meet.dto';
+
+describe('createMeetRequestDto', () => {
+  const baseRequest = {
+    title: '2월 스터디',
+    hostName: '주최자',
+    dates: ['2026-02-20', '2026-02-21'],
+  };
+
+  it('timeRange 미포함 시 성공하고 결과 객체에 timeRange 키가 없다', () => {
+    const result = createMeetRequestDto.parse(baseRequest);
+    expect(result).toEqual(baseRequest);
+    expect('timeRange' in result).toBe(false);
+  });
+
+  it('유효한 timeRange(09:00 ~ 12:00) 포함 시 성공한다', () => {
+    const body = {
+      ...baseRequest,
+      timeRange: { startTime: '09:00', endTime: '12:00' },
+    };
+    const result = createMeetRequestDto.parse(body);
+    expect(result.timeRange).toEqual({
+      startTime: '09:00',
+      endTime: '12:00',
+    });
+  });
+
+  it('startTime이 30분 단위가 아니면 regex 검증에 실패한다', () => {
+    const body = {
+      ...baseRequest,
+      timeRange: { startTime: '09:15', endTime: '12:00' },
+    };
+    expect(() => createMeetRequestDto.parse(body)).toThrow();
+  });
+
+  it('startTime > endTime이면 refine 검증에 실패한다', () => {
+    const body = {
+      ...baseRequest,
+      timeRange: { startTime: '12:00', endTime: '09:00' },
+    };
+    expect(() => createMeetRequestDto.parse(body)).toThrow();
+  });
+
+  it('startTime === endTime이면 refine 검증에 실패한다', () => {
+    const body = {
+      ...baseRequest,
+      timeRange: { startTime: '09:00', endTime: '09:00' },
+    };
+    expect(() => createMeetRequestDto.parse(body)).toThrow();
+  });
+
+  it('endTime이 24:00이면 regex 검증에 실패한다', () => {
+    const body = {
+      ...baseRequest,
+      timeRange: { startTime: '23:30', endTime: '24:00' },
+    };
+    expect(() => createMeetRequestDto.parse(body)).toThrow();
+  });
+});

--- a/src/entities/meet/dto/meet.dto.ts
+++ b/src/entities/meet/dto/meet.dto.ts
@@ -2,6 +2,27 @@ import { z } from 'zod';
 
 // ==================== Zod Schemas ====================
 
+/** "HH:mm" 패턴: 24시간제, 30분 단위만 허용 */
+export const TIME_PATTERN = /^([01]\d|2[0-3]):(00|30)$/;
+
+/**
+ * 시간 범위 스키마
+ * - startTime < endTime (사전식 비교, leading zero 보장)
+ */
+export const timeRangeDto = z
+  .object({
+    startTime: z
+      .string()
+      .regex(TIME_PATTERN, '시각은 "HH:mm" 형식이어야 합니다.'),
+    endTime: z
+      .string()
+      .regex(TIME_PATTERN, '시각은 "HH:mm" 형식이어야 합니다.'),
+  })
+  .refine(({ startTime, endTime }) => startTime < endTime, {
+    message: 'endTime은 startTime보다 커야 합니다.',
+    path: ['endTime'],
+  });
+
 /**
  * 모임 생성 요청 스키마
  * - API 요청 전 클라이언트 측 검증에 사용
@@ -11,6 +32,7 @@ export const createMeetRequestDto = z.object({
   title: z.string().min(1, '모임 이름은 필수입니다.'),
   hostName: z.string().min(1, '모임장 이름은 필수입니다.'),
   dates: z.array(z.string()).min(1, '날짜를 선택해주세요.'),
+  timeRange: timeRangeDto.optional(),
 });
 
 /**
@@ -51,6 +73,11 @@ export const meetResponseDto = z.object({
 });
 
 // ==================== TypeScript Types ====================
+
+/**
+ * 시간 범위 페이로드 타입
+ */
+export type TimeRangePayload = z.infer<typeof timeRangeDto>;
 
 /**
  * 모임 생성 요청 타입

--- a/src/features/meet-create-date/model/useDateSelect.ts
+++ b/src/features/meet-create-date/model/useDateSelect.ts
@@ -5,6 +5,7 @@ import { useState } from 'react';
 
 import { createMeeting } from '@/entities/meet/api/createMeeting';
 import { updateVote } from '@/entities/meet/api/updateVote';
+import type { TimeRangePayload } from '@/entities/meet/dto/meet.dto';
 import { trackEvent } from '@/shared/lib/amplitude';
 
 export function useDateSelect(hostName: string, meetingName: string) {
@@ -21,7 +22,10 @@ export function useDateSelect(hostName: string, meetingName: string) {
     router.replace(`/create?${params.toString()}`);
   };
 
-  const handleNext = async (formattedDates: string[]) => {
+  const handleNext = async (
+    formattedDates: string[],
+    timeRangePayload?: TimeRangePayload,
+  ) => {
     if (formattedDates.length === 0) {
       alert('날짜를 선택해주세요.');
       return;
@@ -29,6 +33,9 @@ export function useDateSelect(hostName: string, meetingName: string) {
 
     trackEvent('host_create_meeting_cta_click', {
       total_days: formattedDates.length,
+      time_range_enabled: Boolean(timeRangePayload),
+      start_time: timeRangePayload?.startTime,
+      end_time: timeRangePayload?.endTime,
     });
 
     try {
@@ -36,6 +43,7 @@ export function useDateSelect(hostName: string, meetingName: string) {
         title: meetingName,
         hostName,
         dates: formattedDates,
+        timeRange: timeRangePayload,
       });
 
       console.log('모임 생성 완료:', response);

--- a/src/features/meet-create-date/ui/DateSelectPage.tsx
+++ b/src/features/meet-create-date/ui/DateSelectPage.tsx
@@ -1,7 +1,12 @@
 'use client';
 
+import { useCallback, useState } from 'react';
+
 import { useDateSelection } from '@/features/host-range-selector/model/useDateSelection';
 import { ReactDatepickerAdapter } from '@/features/host-range-selector/ui/ReactDatepickerAdapter';
+import { formatTime } from '@/features/time-range-select/lib/timeUtils';
+import type { TimeValue } from '@/features/time-range-select/model/types';
+import TimeRangePicker from '@/features/time-range-select/ui/TimeRangePicker';
 import { trackEvent } from '@/shared/lib/amplitude';
 import BottomSheet from '@/shared/ui/bottom-sheet/BottomSheet';
 import Button from '@/shared/ui/button/Button';
@@ -29,6 +34,19 @@ export default function DateSelectPage({
   const { selectedDates, handleDateChange, formattedDates } =
     useDateSelection();
 
+  const [isTimeRangeEnabled, setIsTimeRangeEnabled] = useState(false);
+  const [timeRange, setTimeRange] = useState<{
+    startTime: TimeValue;
+    endTime: TimeValue;
+  } | null>(null);
+
+  const handleRangeChange = useCallback(
+    (range: { startTime: TimeValue; endTime: TimeValue } | null) => {
+      setTimeRange(range);
+    },
+    [],
+  );
+
   const handleDateChangeWithTracking = (updater: (prev: Date[]) => Date[]) => {
     handleDateChange((prev) => {
       const next = updater(prev);
@@ -36,6 +54,20 @@ export default function DateSelectPage({
       return next;
     });
   };
+
+  const isCtaDisabled =
+    selectedDates.length === 0 || (isTimeRangeEnabled && timeRange === null);
+
+  function handleCtaClick() {
+    const payload =
+      isTimeRangeEnabled && timeRange
+        ? {
+            startTime: formatTime(timeRange.startTime),
+            endTime: formatTime(timeRange.endTime),
+          }
+        : undefined;
+    handleNext(formattedDates, payload);
+  }
 
   return (
     <div className='bg-gray-0 min-h-screen-safe flex flex-col'>
@@ -56,19 +88,24 @@ export default function DateSelectPage({
         </h1>
 
         {/* 캘린더 영역 */}
-        <div className='mb-6 flex flex-1 justify-center'>
+        <div className='mb-6 flex justify-center'>
           <ReactDatepickerAdapter
             selectedDates={selectedDates}
             onChange={handleDateChangeWithTracking}
           />
         </div>
 
+        {/* 시간 투표 섹션 */}
+        <div className='mb-6 flex-1'>
+          <TimeRangePicker
+            isEnabled={isTimeRangeEnabled}
+            onEnabledChange={setIsTimeRangeEnabled}
+            onRangeChange={handleRangeChange}
+          />
+        </div>
+
         {/* CTA 버튼 */}
-        <Button
-          onClick={() => handleNext(formattedDates)}
-          fullWidth
-          disabled={selectedDates.length === 0}
-        >
+        <Button onClick={handleCtaClick} fullWidth disabled={isCtaDisabled}>
           모임 만들기
         </Button>
       </main>

--- a/src/features/time-range-select/lib/timeUtils.test.ts
+++ b/src/features/time-range-select/lib/timeUtils.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatTime,
+  generateTimeSlots,
+  getEndTimeOptions,
+  isValidTimeRange,
+  timeToMinutes,
+} from './timeUtils';
+
+describe('generateTimeSlots', () => {
+  it('48개 슬롯을 생성한다', () => {
+    const slots = generateTimeSlots();
+    expect(slots).toHaveLength(48);
+  });
+
+  it('00:00으로 시작한다', () => {
+    const slots = generateTimeSlots();
+    expect(slots[0]).toEqual({ hour: 0, minute: 0 });
+  });
+
+  it('23:30으로 끝난다', () => {
+    const slots = generateTimeSlots();
+    expect(slots[47]).toEqual({ hour: 23, minute: 30 });
+  });
+
+  it('30분 간격으로 증가한다', () => {
+    const slots = generateTimeSlots();
+    expect(slots[1]).toEqual({ hour: 0, minute: 30 });
+    expect(slots[2]).toEqual({ hour: 1, minute: 0 });
+    expect(slots[3]).toEqual({ hour: 1, minute: 30 });
+  });
+});
+
+describe('formatTime', () => {
+  it('10:00 포맷', () => {
+    expect(formatTime({ hour: 10, minute: 0 })).toBe('10:00');
+  });
+
+  it('한 자리 시각은 0 패딩', () => {
+    expect(formatTime({ hour: 9, minute: 30 })).toBe('09:30');
+  });
+
+  it('자정 00:00', () => {
+    expect(formatTime({ hour: 0, minute: 0 })).toBe('00:00');
+  });
+
+  it('23:30 포맷', () => {
+    expect(formatTime({ hour: 23, minute: 30 })).toBe('23:30');
+  });
+});
+
+describe('timeToMinutes', () => {
+  it('10:30 → 630', () => {
+    expect(timeToMinutes({ hour: 10, minute: 30 })).toBe(630);
+  });
+
+  it('00:00 → 0', () => {
+    expect(timeToMinutes({ hour: 0, minute: 0 })).toBe(0);
+  });
+
+  it('23:30 → 1410', () => {
+    expect(timeToMinutes({ hour: 23, minute: 30 })).toBe(1410);
+  });
+});
+
+describe('isValidTimeRange', () => {
+  it('종료 > 시작 → true', () => {
+    expect(
+      isValidTimeRange({ hour: 10, minute: 0 }, { hour: 22, minute: 0 }),
+    ).toBe(true);
+  });
+
+  it('종료 = 시작 (동일) → false', () => {
+    expect(
+      isValidTimeRange({ hour: 10, minute: 0 }, { hour: 10, minute: 0 }),
+    ).toBe(false);
+  });
+
+  it('종료 < 시작 (역전) → false', () => {
+    expect(
+      isValidTimeRange({ hour: 14, minute: 0 }, { hour: 13, minute: 30 }),
+    ).toBe(false);
+  });
+
+  it('23:00 → 23:30 → true', () => {
+    expect(
+      isValidTimeRange({ hour: 23, minute: 0 }, { hour: 23, minute: 30 }),
+    ).toBe(true);
+  });
+});
+
+describe('getEndTimeOptions', () => {
+  const allSlots = generateTimeSlots();
+
+  it('시작 시각 10:00이면 10:00 이하는 disabled', () => {
+    const options = getEndTimeOptions({ hour: 10, minute: 0 }, allSlots);
+    expect(options).toHaveLength(48);
+    // 00:00 ~ 10:00 (인덱스 0~20) → disabled
+    for (let i = 0; i <= 20; i++) {
+      expect(options[i].isDisabled).toBe(true);
+    }
+    // 10:30 (인덱스 21) ~ 23:30 → enabled
+    for (let i = 21; i < 48; i++) {
+      expect(options[i].isDisabled).toBe(false);
+    }
+  });
+
+  it('label은 formatTime 결과와 동일하다', () => {
+    const options = getEndTimeOptions({ hour: 10, minute: 0 }, allSlots);
+    expect(options[0].label).toBe('00:00');
+    expect(options[47].label).toBe('23:30');
+  });
+
+  it('value는 원본 TimeValue와 동일하다', () => {
+    const options = getEndTimeOptions({ hour: 10, minute: 0 }, allSlots);
+    expect(options[0].value).toEqual({ hour: 0, minute: 0 });
+  });
+});
+
+describe('Edge cases', () => {
+  const allSlots = generateTimeSlots();
+
+  it('23:00 시작이면 종료 옵션은 23:30만 활성화', () => {
+    const options = getEndTimeOptions({ hour: 23, minute: 0 }, allSlots);
+    const enabled = options.filter((o) => !o.isDisabled);
+    expect(enabled).toHaveLength(1);
+    expect(enabled[0].value).toEqual({ hour: 23, minute: 30 });
+  });
+
+  it('23:30 시작이면 종료 옵션은 모두 비활성화', () => {
+    const options = getEndTimeOptions({ hour: 23, minute: 30 }, allSlots);
+    expect(options.every((o) => o.isDisabled)).toBe(true);
+  });
+
+  it('자정 경계 23:30 formatTime은 "23:30"이다', () => {
+    expect(formatTime({ hour: 23, minute: 30 })).toBe('23:30');
+  });
+
+  it('30분 경계 09:00/09:30은 서로 유효한 범위를 이룬다', () => {
+    expect(
+      isValidTimeRange({ hour: 9, minute: 0 }, { hour: 9, minute: 30 }),
+    ).toBe(true);
+    expect(
+      isValidTimeRange({ hour: 9, minute: 30 }, { hour: 9, minute: 0 }),
+    ).toBe(false);
+  });
+
+  it('09:00 시작 기준 getEndTimeOptions는 09:00 이하를 모두 disable한다', () => {
+    const options = getEndTimeOptions({ hour: 9, minute: 0 }, allSlots);
+    // 00:00 ~ 09:00 (0 ~ 18 인덱스) → disabled
+    for (let i = 0; i <= 18; i++) {
+      expect(options[i].isDisabled).toBe(true);
+    }
+    // 09:30 이후 → enabled
+    for (let i = 19; i < 48; i++) {
+      expect(options[i].isDisabled).toBe(false);
+    }
+  });
+
+  it('09:30 시작 기준 09:30까지 disable, 10:00부터 enable', () => {
+    const options = getEndTimeOptions({ hour: 9, minute: 30 }, allSlots);
+    expect(options.find((o) => o.label === '09:30')?.isDisabled).toBe(true);
+    expect(options.find((o) => o.label === '10:00')?.isDisabled).toBe(false);
+  });
+});

--- a/src/features/time-range-select/lib/timeUtils.ts
+++ b/src/features/time-range-select/lib/timeUtils.ts
@@ -1,0 +1,46 @@
+import type { TimeOption, TimeValue } from '../model/types';
+
+/** 모듈 초기화 시 1회 생성되는 48개 슬롯 상수 */
+const ALL_SLOTS: TimeValue[] = (() => {
+  const slots: TimeValue[] = [];
+  for (let hour = 0; hour < 24; hour++) {
+    slots.push({ hour, minute: 0 });
+    slots.push({ hour, minute: 30 });
+  }
+  return slots;
+})();
+
+/** 00:00~23:30, 30분 간격 48개 슬롯을 반환한다 */
+export function generateTimeSlots(): TimeValue[] {
+  return ALL_SLOTS;
+}
+
+/** TimeValue를 "HH:mm" 형식 문자열로 변환한다 */
+export function formatTime(value: TimeValue): string {
+  const hh = String(value.hour).padStart(2, '0');
+  const mm = String(value.minute).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+/** TimeValue를 자정 기준 분 단위 숫자로 변환한다 */
+export function timeToMinutes(value: TimeValue): number {
+  return value.hour * 60 + value.minute;
+}
+
+/** 종료 시각이 시작 시각보다 엄격히 큰지 검사한다 */
+export function isValidTimeRange(start: TimeValue, end: TimeValue): boolean {
+  return timeToMinutes(end) > timeToMinutes(start);
+}
+
+/** 전체 슬롯 중 시작 시각 이하는 disabled, 초과는 enabled로 반환한다 */
+export function getEndTimeOptions(
+  startTime: TimeValue,
+  allSlots: TimeValue[],
+): TimeOption[] {
+  const startMinutes = timeToMinutes(startTime);
+  return allSlots.map((slot) => ({
+    value: slot,
+    label: formatTime(slot),
+    isDisabled: timeToMinutes(slot) <= startMinutes,
+  }));
+}

--- a/src/features/time-range-select/model/types.ts
+++ b/src/features/time-range-select/model/types.ts
@@ -1,0 +1,21 @@
+/** 분 단위: 0 또는 30만 허용 */
+type Minute = 0 | 30;
+
+/** 타임존 독립 시각 값 객체 */
+export interface TimeValue {
+  hour: number; // 0~23
+  minute: Minute; // 0 또는 30
+}
+
+/** 시작 시각과 종료 시각으로 구성된 시간 범위 */
+export interface TimeRange {
+  startTime: TimeValue | null;
+  endTime: TimeValue | null;
+}
+
+/** 피커에서 표시되는 개별 시간 항목 */
+export interface TimeOption {
+  value: TimeValue;
+  label: string;
+  isDisabled: boolean;
+}

--- a/src/features/time-range-select/model/useTimeRangeSelect.ts
+++ b/src/features/time-range-select/model/useTimeRangeSelect.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import {
+  generateTimeSlots,
+  getEndTimeOptions,
+  isValidTimeRange,
+  timeToMinutes,
+} from '../lib/timeUtils';
+import type { TimeOption, TimeValue } from './types';
+
+interface UseTimeRangeSelectOptions {
+  initialStartTime?: TimeValue;
+  initialEndTime?: TimeValue;
+  onChange?: (range: { startTime: TimeValue; endTime: TimeValue }) => void;
+}
+
+interface UseTimeRangeSelectReturn {
+  startTime: TimeValue | null;
+  endTime: TimeValue | null;
+  isComplete: boolean;
+  isValid: boolean;
+  handleStartTimeChange: (value: TimeValue) => void;
+  handleEndTimeChange: (value: TimeValue) => void;
+  endTimeOptions: TimeOption[];
+  allSlots: TimeValue[];
+}
+
+export function useTimeRangeSelect({
+  initialStartTime,
+  initialEndTime,
+  onChange,
+}: UseTimeRangeSelectOptions = {}): UseTimeRangeSelectReturn {
+  const [startTime, setStartTime] = useState<TimeValue | null>(
+    initialStartTime ?? null,
+  );
+  const [endTime, setEndTime] = useState<TimeValue | null>(
+    initialEndTime ?? null,
+  );
+
+  const allSlots = useMemo(() => generateTimeSlots(), []);
+
+  const endTimeOptions = useMemo(
+    () =>
+      startTime
+        ? getEndTimeOptions(startTime, allSlots)
+        : allSlots.map((slot) => ({
+            value: slot,
+            label: `${String(slot.hour).padStart(2, '0')}:${String(slot.minute).padStart(2, '0')}`,
+            isDisabled: false,
+          })),
+    [startTime, allSlots],
+  );
+
+  const isComplete = startTime !== null && endTime !== null;
+  const isValid =
+    isComplete &&
+    isValidTimeRange(startTime as TimeValue, endTime as TimeValue);
+
+  function handleStartTimeChange(value: TimeValue) {
+    setStartTime(value);
+    // 기존 endTime이 새 startTime 이하이면 초기화
+    if (endTime !== null && timeToMinutes(endTime) <= timeToMinutes(value)) {
+      setEndTime(null);
+    }
+  }
+
+  function handleEndTimeChange(value: TimeValue) {
+    if (startTime !== null && !isValidTimeRange(startTime, value)) return;
+    setEndTime(value);
+    if (startTime !== null) {
+      onChange?.({ startTime, endTime: value });
+    }
+  }
+
+  return {
+    startTime,
+    endTime,
+    isComplete,
+    isValid,
+    handleStartTimeChange,
+    handleEndTimeChange,
+    endTimeOptions,
+    allSlots,
+  };
+}

--- a/src/features/time-range-select/ui/TimeRangePicker.tsx
+++ b/src/features/time-range-select/ui/TimeRangePicker.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import BottomSheet from '@/shared/ui/bottom-sheet/BottomSheet';
+import Button from '@/shared/ui/button/Button';
+import Toggle from '@/shared/ui/toggle/Toggle';
+
+import { isValidTimeRange, timeToMinutes } from '../lib/timeUtils';
+import type { TimeValue } from '../model/types';
+import { useTimeRangeSelect } from '../model/useTimeRangeSelect';
+import TimeWheelPicker from './TimeWheelPicker';
+
+const DEFAULT_START_TIME: TimeValue = { hour: 9, minute: 0 };
+const DEFAULT_END_TIME: TimeValue = { hour: 12, minute: 0 };
+
+interface TimeRangePickerProps {
+  isEnabled: boolean;
+  onEnabledChange: (next: boolean) => void;
+  initialStartTime?: TimeValue;
+  initialEndTime?: TimeValue;
+  onRangeChange?: (
+    range: { startTime: TimeValue; endTime: TimeValue } | null,
+  ) => void;
+}
+
+function displayTime(t: TimeValue): string {
+  return `${String(t.hour).padStart(2, '0')} : ${String(t.minute).padStart(2, '0')}`;
+}
+
+/** minTime 이후의 첫 번째 유효 시각을 반환 */
+function firstValidAfter(minTime: TimeValue): TimeValue {
+  if (minTime.minute === 0) return { hour: minTime.hour, minute: 30 };
+  if (minTime.hour < 23) return { hour: minTime.hour + 1, minute: 0 };
+  return minTime;
+}
+
+/** maxTime 이전의 첫 번째 유효 시각을 반환 */
+function lastValidBefore(maxTime: TimeValue): TimeValue {
+  if (maxTime.minute === 30) return { hour: maxTime.hour, minute: 0 };
+  if (maxTime.hour > 0) return { hour: maxTime.hour - 1, minute: 30 };
+  return maxTime;
+}
+
+export default function TimeRangePicker({
+  isEnabled,
+  onEnabledChange,
+  initialStartTime = DEFAULT_START_TIME,
+  initialEndTime = DEFAULT_END_TIME,
+  onRangeChange,
+}: TimeRangePickerProps) {
+  const { startTime, endTime, handleStartTimeChange, handleEndTimeChange } =
+    useTimeRangeSelect({ initialStartTime, initialEndTime });
+
+  const [activeField, setActiveField] = useState<'start' | 'end' | null>(null);
+  const [pendingValue, setPendingValue] =
+    useState<TimeValue>(DEFAULT_START_TIME);
+
+  useEffect(() => {
+    if (!isEnabled) {
+      onRangeChange?.(null);
+      return;
+    }
+    if (
+      startTime !== null &&
+      endTime !== null &&
+      isValidTimeRange(startTime, endTime)
+    ) {
+      onRangeChange?.({ startTime, endTime });
+    } else {
+      onRangeChange?.(null);
+    }
+  }, [isEnabled, startTime, endTime, onRangeChange]);
+
+  function openPicker(field: 'start' | 'end') {
+    if (field === 'end') {
+      const start = startTime ?? DEFAULT_START_TIME;
+      const current = endTime;
+      const initial =
+        current && isValidTimeRange(start, current)
+          ? current
+          : firstValidAfter(start);
+      setPendingValue(initial);
+    } else {
+      const end = endTime ?? DEFAULT_END_TIME;
+      const current = startTime;
+      const initial =
+        current && isValidTimeRange(current, end)
+          ? current
+          : lastValidBefore(end);
+      setPendingValue(initial);
+    }
+    setActiveField(field);
+  }
+
+  function handleConfirm() {
+    if (activeField === 'start') {
+      handleStartTimeChange(pendingValue);
+    } else if (activeField === 'end') {
+      handleEndTimeChange(pendingValue);
+    }
+    setActiveField(null);
+  }
+
+  function handleCancel() {
+    setActiveField(null);
+  }
+
+  const sheetLabel = activeField === 'start' ? '시작 시간' : '종료 시간';
+
+  const pickerConstraint =
+    activeField === 'end'
+      ? { minTime: startTime ?? undefined }
+      : { maxTime: endTime ?? undefined };
+
+  const isEndInvalid =
+    endTime !== null &&
+    startTime !== null &&
+    timeToMinutes(endTime) <= timeToMinutes(startTime);
+
+  return (
+    <>
+      <section className='px-5 py-4'>
+        {/* 섹션 헤더 + 토글 */}
+        <div className='flex items-center justify-between'>
+          <span className='text-text-primary text-lg font-bold'>
+            시간 투표 받기
+          </span>
+          <Toggle
+            checked={isEnabled}
+            onChange={onEnabledChange}
+            ariaLabel='시간 투표 받기 토글'
+          />
+        </div>
+
+        {isEnabled && (
+          <div className='mt-4 flex flex-col gap-3'>
+            {/* 시작 시간 카드 */}
+            <button
+              type='button'
+              onClick={() => openPicker('start')}
+              className='flex w-full items-center justify-between rounded-2xl border border-gray-200 px-5 py-4'
+            >
+              <span className='text-text-primary text-base font-medium'>
+                시작 시간
+              </span>
+              <span className='text-text-primary text-base font-semibold tabular-nums'>
+                {displayTime(startTime ?? DEFAULT_START_TIME)}
+              </span>
+            </button>
+
+            {/* 종료 시간 카드 */}
+            <button
+              type='button'
+              onClick={() => openPicker('end')}
+              className='flex w-full items-center justify-between rounded-2xl border border-gray-200 px-5 py-4'
+            >
+              <span className='text-text-primary text-base font-medium'>
+                종료 시간
+              </span>
+              <span
+                className={`text-base font-semibold tabular-nums ${
+                  isEndInvalid ? 'text-red-400' : 'text-text-primary'
+                }`}
+              >
+                {displayTime(endTime ?? DEFAULT_END_TIME)}
+              </span>
+            </button>
+          </div>
+        )}
+      </section>
+
+      {/* 바텀 시트 — 휠 피커 */}
+      <BottomSheet
+        isOpen={activeField !== null}
+        onClose={handleCancel}
+        showCloseButton={false}
+      >
+        <div className='pt-2'>
+          <p className='text-text-primary mb-4 text-center text-base font-semibold'>
+            {sheetLabel}
+          </p>
+          <TimeWheelPicker
+            value={pendingValue}
+            onChange={setPendingValue}
+            {...pickerConstraint}
+          />
+          <Button fullWidth onClick={handleConfirm} className='mt-6'>
+            확인
+          </Button>
+        </div>
+      </BottomSheet>
+    </>
+  );
+}

--- a/src/features/time-range-select/ui/TimeWheelColumn.tsx
+++ b/src/features/time-range-select/ui/TimeWheelColumn.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const ITEM_HEIGHT = 56; // px per item
+const CONTAINER_HEIGHT = ITEM_HEIGHT * 5; // 280px — 5 items visible
+const PAD_SIZE = ITEM_HEIGHT * 2; // top/bottom padding for first/last item centering
+
+interface TimeWheelColumnProps {
+  items: number[];
+  value: number;
+  onChange: (value: number) => void;
+  formatItem?: (n: number) => string;
+}
+
+export default function TimeWheelColumn({
+  items,
+  value,
+  onChange,
+  formatItem = String,
+}: TimeWheelColumnProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollEndTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const selectedIndex = items.indexOf(value);
+
+  // scrollPos as float for real-time fade: initialized to selectedIndex
+  const [scrollPos, setScrollPos] = useState(
+    selectedIndex >= 0 ? selectedIndex : 0,
+  );
+
+  // initial scroll on mount — DOM only, no setState
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || selectedIndex < 0) return;
+    el.scrollTop = selectedIndex * ITEM_HEIGHT;
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // sync when value changes externally
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || selectedIndex < 0) return;
+    const current = Math.round(el.scrollTop / ITEM_HEIGHT);
+    if (current !== selectedIndex) {
+      el.scrollTo({ top: selectedIndex * ITEM_HEIGHT, behavior: 'smooth' });
+    }
+  }, [selectedIndex]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    setScrollPos(el.scrollTop / ITEM_HEIGHT);
+
+    if (scrollEndTimer.current) clearTimeout(scrollEndTimer.current);
+    scrollEndTimer.current = setTimeout(() => {
+      const snapped = Math.round(el.scrollTop / ITEM_HEIGHT);
+      const clamped = Math.max(0, Math.min(snapped, items.length - 1));
+      onChange(items[clamped]);
+    }, 150);
+  }, [items, onChange]);
+
+  useEffect(() => {
+    return () => {
+      if (scrollEndTimer.current) clearTimeout(scrollEndTimer.current);
+    };
+  }, []);
+
+  const getItemStyle = (index: number): CSSProperties => {
+    const dist = Math.abs(index - scrollPos);
+    if (dist < 0.7) return { color: '#111827', fontWeight: 700 };
+    if (dist < 1.5) return { color: '#9CA3AF', fontWeight: 400 };
+    return { color: '#D1D5DB', fontWeight: 400 };
+  };
+
+  return (
+    <div
+      ref={scrollRef}
+      onScroll={handleScroll}
+      className='overflow-y-scroll [&::-webkit-scrollbar]:hidden'
+      style={{
+        height: CONTAINER_HEIGHT,
+        scrollSnapType: 'y mandatory',
+        WebkitOverflowScrolling: 'touch',
+        scrollbarWidth: 'none',
+      }}
+    >
+      <div style={{ height: PAD_SIZE }} aria-hidden='true' />
+      {items.map((item, index) => (
+        <div
+          key={item}
+          style={{
+            height: ITEM_HEIGHT,
+            scrollSnapAlign: 'center',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: '24px',
+            cursor: 'pointer',
+            userSelect: 'none',
+            transition: 'color 80ms ease',
+            minHeight: 44,
+            ...getItemStyle(index),
+          }}
+          onClick={() => {
+            scrollRef.current?.scrollTo({
+              top: index * ITEM_HEIGHT,
+              behavior: 'smooth',
+            });
+            onChange(item);
+          }}
+        >
+          {formatItem(item)}
+        </div>
+      ))}
+      <div style={{ height: PAD_SIZE }} aria-hidden='true' />
+    </div>
+  );
+}

--- a/src/features/time-range-select/ui/TimeWheelPicker.tsx
+++ b/src/features/time-range-select/ui/TimeWheelPicker.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import type { TimeValue } from '../model/types';
+import TimeWheelColumn from './TimeWheelColumn';
+
+const ITEM_HEIGHT = 56;
+const CONTAINER_HEIGHT = ITEM_HEIGHT * 5; // 280px
+
+const ALL_HOURS = Array.from({ length: 24 }, (_, i) => i);
+const ALL_MINUTES = [0, 30];
+
+interface TimeWheelPickerProps {
+  value: TimeValue;
+  onChange: (value: TimeValue) => void;
+  /** 종료시간 피커용: value > minTime 이어야 함 */
+  minTime?: TimeValue;
+  /** 시작시간 피커용: value < maxTime 이어야 함 */
+  maxTime?: TimeValue;
+}
+
+export default function TimeWheelPicker({
+  value,
+  onChange,
+  minTime,
+  maxTime,
+}: TimeWheelPickerProps) {
+  // 선택 가능한 시 목록
+  const availableHours = useMemo(() => {
+    if (minTime) {
+      // minTime.minute == 30이면 같은 시에 유효 분이 없으므로 다음 시부터
+      const startHour = minTime.minute === 30 ? minTime.hour + 1 : minTime.hour;
+      return ALL_HOURS.filter((h) => h >= startHour);
+    }
+    if (maxTime) {
+      // maxTime.minute == 0이면 같은 시에 유효 분이 없으므로 이전 시까지
+      const endHour = maxTime.minute === 0 ? maxTime.hour - 1 : maxTime.hour;
+      return ALL_HOURS.filter((h) => h <= endHour);
+    }
+    return ALL_HOURS;
+  }, [minTime, maxTime]);
+
+  // 현재 선택된 시 기준 선택 가능한 분 목록
+  const availableMinutes = useMemo(() => {
+    if (minTime && value.hour === minTime.hour) {
+      // 같은 시: minTime.minute(== 0) 초과만 유효 → [30]
+      return ALL_MINUTES.filter((m) => m > minTime.minute);
+    }
+    if (maxTime && value.hour === maxTime.hour) {
+      // 같은 시: maxTime.minute(== 30) 미만만 유효 → [0]
+      return ALL_MINUTES.filter((m) => m < maxTime.minute);
+    }
+    return ALL_MINUTES;
+  }, [minTime, maxTime, value.hour]);
+
+  function handleHourChange(hour: number) {
+    // 시가 바뀌면 분의 유효 범위도 바뀔 수 있으므로 자동 보정
+    let newMins = ALL_MINUTES;
+    if (minTime && hour === minTime.hour)
+      newMins = ALL_MINUTES.filter((m) => m > minTime.minute);
+    if (maxTime && hour === maxTime.hour)
+      newMins = ALL_MINUTES.filter((m) => m < maxTime.minute);
+
+    const minute = newMins.includes(value.minute)
+      ? value.minute
+      : ((newMins[0] ?? 0) as 0 | 30);
+
+    onChange({ hour, minute });
+  }
+
+  function handleMinuteChange(minute: number) {
+    onChange({ ...value, minute: minute as 0 | 30 });
+  }
+
+  // 현재 value가 유효 범위를 벗어났을 경우 첫 번째 유효값으로 안전하게 표시
+  const safeHour = availableHours.includes(value.hour)
+    ? value.hour
+    : (availableHours[0] ?? 0);
+  const safeMinute = availableMinutes.includes(value.minute)
+    ? value.minute
+    : ((availableMinutes[0] ?? 0) as 0 | 30);
+
+  return (
+    <div className='relative w-full' style={{ height: CONTAINER_HEIGHT }}>
+      {/*
+       * z-index 레이어 구조:
+       *   0 (bottom) — 선택 배경 (bg-gray-50)
+       *  10 (middle) — 컬럼 텍스트 (columns wrapper)
+       *  20 (top)    — 선택 테두리 (pointer-events:none)
+       * → 텍스트가 배경 위에 표시되면서 테두리가 그 위를 감쌈
+       */}
+
+      {/* Layer 0: 선택 배경 */}
+      <div
+        className='absolute inset-x-6 rounded-2xl bg-gray-50'
+        style={{
+          top: '50%',
+          transform: 'translateY(-50%)',
+          height: ITEM_HEIGHT,
+          zIndex: 0,
+        }}
+      />
+
+      {/* Layer 10: 컬럼 */}
+      <div
+        className='relative flex h-full items-center justify-center'
+        style={{ zIndex: 10 }}
+      >
+        <div className='flex-1'>
+          <TimeWheelColumn
+            items={availableHours}
+            value={safeHour}
+            onChange={handleHourChange}
+            formatItem={String}
+          />
+        </div>
+
+        <span
+          className='shrink-0 px-1 text-2xl font-bold text-gray-800 select-none'
+          aria-hidden='true'
+        >
+          :
+        </span>
+
+        <div className='flex-1'>
+          <TimeWheelColumn
+            items={availableMinutes.length > 0 ? availableMinutes : ALL_MINUTES}
+            value={safeMinute}
+            onChange={handleMinuteChange}
+            formatItem={(n) => String(n).padStart(2, '0')}
+          />
+        </div>
+      </div>
+
+      {/* Layer 20: 선택 테두리 */}
+      <div
+        className='pointer-events-none absolute inset-x-6 rounded-2xl border border-gray-200'
+        style={{
+          top: '50%',
+          transform: 'translateY(-50%)',
+          height: ITEM_HEIGHT,
+          zIndex: 20,
+        }}
+      />
+    </div>
+  );
+}

--- a/src/shared/ui/toggle/Toggle.tsx
+++ b/src/shared/ui/toggle/Toggle.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { KeyboardEvent } from 'react';
+
+import { cn } from '@/shared/lib/utils';
+
+const toggleTrackVariants = cva(
+  'relative inline-flex h-[28px] w-[48px] items-center rounded-full transition-colors duration-200 ease-in-out',
+  {
+    variants: {
+      state: {
+        on: 'bg-primary-default',
+        off: 'bg-gray-200',
+      },
+    },
+    defaultVariants: {
+      state: 'off',
+    },
+  },
+);
+
+const toggleThumbVariants = cva(
+  'pointer-events-none inline-block h-[24px] w-[24px] transform rounded-full bg-white shadow-sm transition-transform duration-200 ease-in-out',
+  {
+    variants: {
+      state: {
+        on: 'translate-x-[22px]',
+        off: 'translate-x-[2px]',
+      },
+    },
+    defaultVariants: {
+      state: 'off',
+    },
+  },
+);
+
+interface ToggleProps extends VariantProps<typeof toggleTrackVariants> {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  disabled?: boolean;
+  id?: string;
+  ariaLabel?: string;
+  className?: string;
+}
+
+export default function Toggle({
+  checked,
+  onChange,
+  disabled = false,
+  id,
+  ariaLabel,
+  className,
+}: ToggleProps) {
+  const state = checked ? 'on' : 'off';
+
+  function handleClick() {
+    if (disabled) return;
+    onChange(!checked);
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    if (disabled) return;
+    if (event.key === ' ' || event.key === 'Enter') {
+      event.preventDefault();
+      onChange(!checked);
+    }
+  }
+
+  return (
+    <button
+      type='button'
+      role='switch'
+      id={id}
+      aria-label={ariaLabel}
+      aria-checked={checked}
+      aria-disabled={disabled || undefined}
+      disabled={disabled}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        'inline-flex h-11 min-w-12 items-center justify-center rounded-full p-0',
+        'focus-visible:ring-primary-default focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none',
+        disabled && 'cursor-not-allowed opacity-50',
+        !disabled && 'cursor-pointer',
+        className,
+      )}
+    >
+      <span className={cn(toggleTrackVariants({ state }))} aria-hidden='true'>
+        <span className={cn(toggleThumbVariants({ state }))} />
+      </span>
+    </button>
+  );
+}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #131

# 📝 작업 내용

## 🎯 어떤 기능인가요?

날짜 선택 페이지에 **시간 투표 받기** 기능을 추가했습니다. 호스트가 참여자들이 투표할 수 있는 시간 범위(시작~종료)를 설정할 수 있습니다. 30분 단위 휠 피커를 사용하며, 모바일 환경에서도 정상 작동합니다.

## ✅ 어떻게 구현했나요?

### 1. 시간 범위 선택 피처 (`src/features/time-range-select/`)

| 파일 | 역할 |
|------|------|
| `model/types.ts` | `TimeValue` 타입 정의 (`{ hour, minute }`) |
| `model/useTimeRangeSelect.ts` | 시작/종료 시간 상태 관리 훅. 종료 시간이 시작 시간 이하로 바뀌면 자동 초기화 |
| `lib/timeUtils.ts` | 시간 슬롯 생성, 유효성 검증, `formatTime` 등 순수 유틸 함수 |
| `lib/timeUtils.test.ts` | 유틸 함수 단위 테스트 |
| `ui/TimeWheelPicker.tsx` | 시간/분 두 컬럼 휠 피커 컴포넌트 |
| `ui/TimeWheelColumn.tsx` | 단일 컬럼 스크롤 휠 (snap scroll 기반) |
| `ui/TimeRangePicker.tsx` | 토글 + 시작/종료 시간 카드 + 바텀시트 조합 컴포넌트 |

### 2. 토글 공유 컴포넌트 (`src/shared/ui/toggle/Toggle.tsx`)

재사용 가능한 토글 스위치 컴포넌트를 `shared/ui`에 추가했습니다.

### 3. DTO 및 검증 스키마 (`src/entities/meet/dto/meet.dto.ts`)

`timeRangeDto` Zod 스키마를 추가했습니다.
- `HH:mm` 패턴 (24시간제, 30분 단위) 검증
- `startTime < endTime` 조건 검증
- `createMeetRequestDto`에 `timeRange?: timeRangeDto` 필드 추가

### 4. 날짜 선택 페이지 통합 (`src/features/meet-create-date/ui/DateSelectPage.tsx`)
<img width="680" height="948" alt="image" src="https://github.com/user-attachments/assets/fed145c2-3e50-478d-b065-96dbda463804" />
<img width="680" height="948" alt="image" src="https://github.com/user-attachments/assets/f1b077da-3b6e-46a0-a9c4-090fcd376ddc" />

- `TimeRangePicker` 컴포넌트를 캘린더 아래에 배치
- **CTA 활성/비활성 정책**:
  - 날짜 미선택 → 비활성
  - 날짜 선택 + 토글 OFF → 활성
  - 날짜 선택 + 토글 ON + 기본값(09:00~12:00) → 활성 (기본값이 유효 범위이므로 통과)
  - 날짜 선택 + 토글 ON + 유효성 실패 → 비활성
- `handleNext`에 `timeRangePayload` 전달하여 API 요청에 포함

## 📁 변경 파일 요약

| 파일 | 변경 내용 |
|------|----------|
| `src/features/time-range-select/` | 시간 범위 선택 피처 신규 추가 |
| `src/shared/ui/toggle/Toggle.tsx` | 토글 공유 컴포넌트 신규 추가 |
| `src/entities/meet/dto/meet.dto.ts` | `timeRangeDto`, `TimeRangePayload` 추가 |
| `src/entities/meet/dto/meet.dto.test.ts` | DTO 단위 테스트 추가 |
| `src/features/meet-create-date/ui/DateSelectPage.tsx` | `TimeRangePicker` 통합, CTA 비활성 조건 추가 |
| `src/features/meet-create-date/model/useDateSelect.ts` | `handleNext`에 `timeRangePayload` 파라미터 추가 |
| `src/app/test/time-picker/page.tsx` | 개발용 테스트 페이지 (디자인 확정 전 임시) |

# 🗣️ 리뷰 요구사항 (선택)